### PR TITLE
API-2: feat: add google oauth integration

### DIFF
--- a/backend/config/passport.js
+++ b/backend/config/passport.js
@@ -1,0 +1,82 @@
+const passport = require('passport');
+const { Strategy: GoogleStrategy } = require('passport-google-oauth20');
+const User = require('../models/User');
+
+// ============================================================
+// PASSPORT CONFIG
+// Purpose: Configure Google OAuth strategy for authentication
+// Used by: server.js (passport.initialize()), auth.routes.js (passport.authenticate)
+// Flow: Google redirects back with profile → find or create user → return user to callback
+// Note: Session support is disabled (session: false) — we use JWT instead
+// ============================================================
+
+passport.use(
+    new GoogleStrategy(
+        // ----------------------------------------
+        // Strategy Options
+        // Purpose: Tell Passport how to talk to Google
+        // ----------------------------------------
+        {
+            clientID: process.env.GOOGLE_CLIENT_ID,
+            clientSecret: process.env.GOOGLE_CLIENT_SECRET,
+            callbackURL: process.env.GOOGLE_CALLBACK_URL,
+
+            // Return more profile fields (email, name, photo)
+            scope: ['profile', 'email'],
+        },
+
+        // ----------------------------------------
+        // Verify Callback
+        // Purpose: Runs after Google redirects back — find or create the user
+        // Params: accessToken, refreshToken (Google tokens), profile (Google user data), done (Passport callback)
+        // ----------------------------------------
+        async (accessToken, refreshToken, profile, done) => {
+            try {
+                const email = profile.emails[0].value;
+                const googleId = profile.id;
+
+                // Case 1: User already linked this Google account — just log them in
+                let user = await User.findOne({ googleId });
+                if (user) {
+                    // Refresh tokens in case they rotated
+                    user.googleAccessToken = accessToken;
+                    user.googleRefreshToken = refreshToken || user.googleRefreshToken;
+                    user.googleTokenExpiry = new Date(Date.now() + 3600 * 1000); // ~1hr estimate
+                    await user.save();
+                    return done(null, user);
+                }
+
+                // Case 2: User exists by email but hasn't linked Google yet — link the accounts
+                user = await User.findOne({ email });
+                if (user) {
+                    user.googleId = googleId;
+                    user.googleAccessToken = accessToken;
+                    user.googleRefreshToken = refreshToken;
+                    user.googleTokenExpiry = new Date(Date.now() + 3600 * 1000);
+                    await user.save();
+                    return done(null, user);
+                }
+
+                // Case 3: Brand new user — create account from Google profile
+                // username derived from email prefix (e.g. john.doe@gmail.com → john.doe)
+                const username = email.split('@')[0];
+                user = await User.create({
+                    email,
+                    username,
+                    firstName: profile.name.givenName,
+                    lastName: profile.name.familyName,
+                    googleId,
+                    googleAccessToken: accessToken,
+                    googleRefreshToken: refreshToken,
+                    googleTokenExpiry: new Date(Date.now() + 3600 * 1000),
+                });
+
+                return done(null, user);
+            } catch (err) {
+                return done(err, null);
+            }
+        }
+    )
+);
+
+module.exports = passport;

--- a/backend/controllers/auth.controller.js
+++ b/backend/controllers/auth.controller.js
@@ -9,7 +9,8 @@ const resend = new Resend(process.env.RESEND_API_KEY);
 // AUTH CONTROLLER
 // Purpose: Handle business logic for all authentication endpoints
 // Used by: routes/auth.routes.js
-// Endpoints: register, login, me, forgotPassword, resetPassword
+// Endpoints: register, login, me, forgotPassword, resetPassword,
+//            googleCallback, googleLink, googleUnlink
 // ============================================================
 
 // ----------------------------------------
@@ -140,4 +141,60 @@ exports.resetPassword = async (req, res) => {
     await user.save();
 
     res.status(200).json({ success: true, message: 'Password reset successful' });
+};
+
+// ----------------------------------------
+// GET /api/auth/google/callback
+// Purpose: Passport has already verified the Google token and attached the user to req.user
+//          Sign a JWT and redirect to the frontend with it as a query param
+// ----------------------------------------
+exports.googleCallback = (req, res) => {
+    const token = signToken(req.user._id);
+
+    // Redirect to frontend — token passed as query param so the client can store it
+    res.redirect(`${process.env.FRONTEND_URL}/auth/callback?token=${token}`);
+};
+
+// ----------------------------------------
+// POST /api/auth/me/google/link
+// Purpose: Link a Google account to an existing email/password user
+//          req.body contains the googleId and tokens from a client-side Google sign-in
+// ----------------------------------------
+exports.googleLink = async (req, res) => {
+    const { googleId, googleAccessToken, googleRefreshToken } = req.body;
+
+    // Prevent linking a googleId that's already tied to another account
+    const alreadyLinked = await User.findOne({ googleId });
+    if (alreadyLinked) {
+        return res.status(409).json({ success: false, error: 'This Google account is already linked to another user' });
+    }
+
+    // Attach Google fields to the current user (req.user set by authMiddleware)
+    req.user.googleId = googleId;
+    req.user.googleAccessToken = googleAccessToken;
+    req.user.googleRefreshToken = googleRefreshToken;
+    req.user.googleTokenExpiry = new Date(Date.now() + 3600 * 1000);
+    await req.user.save();
+
+    res.status(200).json({ success: true, user: req.user });
+};
+
+// ----------------------------------------
+// DELETE /api/auth/me/google/link
+// Purpose: Unlink Google from the current user's account
+//          Only allowed if the user has a password (otherwise they'd be locked out)
+// ----------------------------------------
+exports.googleUnlink = async (req, res) => {
+    // Prevent lockout — Google-only users have no password to fall back on
+    if (!req.user.password) {
+        return res.status(400).json({ success: false, error: 'Set a password before unlinking Google' });
+    }
+
+    req.user.googleId = undefined;
+    req.user.googleAccessToken = undefined;
+    req.user.googleRefreshToken = undefined;
+    req.user.googleTokenExpiry = undefined;
+    await req.user.save();
+
+    res.status(200).json({ success: true, user: req.user });
 };

--- a/backend/models/User.js
+++ b/backend/models/User.js
@@ -31,7 +31,8 @@ const userSchema = new mongoose.Schema({
     },
     password: {
         type: String,
-        required: [true, 'Password is required'],
+        // Not required for Google OAuth users — they authenticate via googleId instead
+        required: [function () { return !this.googleId; }, 'Password is required'],
         minlength: [8, 'Password must be at least 8 characters'],
         validate: {
             validator: function (value) {

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -17,6 +17,8 @@
         "jsonwebtoken": "^9.0.3",
         "mongodb": "^7.0.0",
         "mongoose": "^9.1.4",
+        "passport": "^0.7.0",
+        "passport-google-oauth20": "^2.0.0",
         "resend": "^6.9.2"
       }
     },
@@ -61,6 +63,15 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/base64url": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
+      "integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/bcryptjs": {
@@ -818,6 +829,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/oauth": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.10.2.tgz",
+      "integrity": "sha512-JtFnB+8nxDEXgNyniwz573xxbKSOu3R8D40xQKqcjwJ2CDkYqUDI53o6IuzDJBx60Z8VKCm271+t8iFjakrl8Q==",
+      "license": "MIT"
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -869,6 +886,64 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/passport": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/passport/-/passport-0.7.0.tgz",
+      "integrity": "sha512-cPLl+qZpSc+ireUvt+IzqbED1cHHkDoVYMo30jbJIdOOjQ1MQYZBPiNvmi8UM6lJuOpTPXJGZQk0DtC4y61MYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "passport-strategy": "1.x.x",
+        "pause": "0.0.1",
+        "utils-merge": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/jaredhanson"
+      }
+    },
+    "node_modules/passport-google-oauth20": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/passport-google-oauth20/-/passport-google-oauth20-2.0.0.tgz",
+      "integrity": "sha512-KSk6IJ15RoxuGq7D1UKK/8qKhNfzbLeLrG3gkLZ7p4A6DBCcv7xpyQwuXtWdpyR0+E0mwkpjY1VfPOhxQrKzdQ==",
+      "license": "MIT",
+      "dependencies": {
+        "passport-oauth2": "1.x.x"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/passport-oauth2": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/passport-oauth2/-/passport-oauth2-1.8.0.tgz",
+      "integrity": "sha512-cjsQbOrXIDE4P8nNb3FQRCCmJJ/utnFKEz2NX209f7KOHPoX18gF7gBzBbLLsj2/je4KrgiwLLGjf0lm9rtTBA==",
+      "license": "MIT",
+      "dependencies": {
+        "base64url": "3.x.x",
+        "oauth": "0.10.x",
+        "passport-strategy": "1.x.x",
+        "uid2": "0.0.x",
+        "utils-merge": "1.x.x"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/jaredhanson"
+      }
+    },
+    "node_modules/passport-strategy": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/passport-strategy/-/passport-strategy-1.0.0.tgz",
+      "integrity": "sha512-CB97UUvDKJde2V0KDWWB3lyf6PC3FaZP7YxZ2G8OAtn9p4HI9j9JLP9qjOGZFvyl8uwNT8qM+hGnz/n16NI7oA==",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
     "node_modules/path-to-regexp": {
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
@@ -878,6 +953,11 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/pause": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
+      "integrity": "sha512-KG8UEiEVkR3wGEb4m5yZkVCzigAD+cVEJck2CzYZO37ZGJfctvVptVO192MwrtPhzONn6go8ylnOdMhKqi4nfg=="
     },
     "node_modules/postal-mime": {
       "version": "2.7.3",
@@ -1223,6 +1303,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/uid2": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.4.tgz",
+      "integrity": "sha512-IevTus0SbGwQzYh3+fRsAMTVVPOoIVufzacXcHPmdlle1jUpq7BRL+mw3dgeLanvGZdwwbWhRV6XrcFNdBmjWA==",
+      "license": "MIT"
+    },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -1230,6 +1316,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
       }
     },
     "node_modules/uuid": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -20,6 +20,8 @@
     "jsonwebtoken": "^9.0.3",
     "mongodb": "^7.0.0",
     "mongoose": "^9.1.4",
+    "passport": "^0.7.0",
+    "passport-google-oauth20": "^2.0.0",
     "resend": "^6.9.2"
   }
 }

--- a/backend/routes/auth.routes.js
+++ b/backend/routes/auth.routes.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const router = express.Router();
+const passport = require('../config/passport');
 const authController = require('../controllers/auth.controller');
 const authMiddleware = require('../middleware/auth.middleware');
 
@@ -15,7 +16,29 @@ router.post('/login', authController.login);
 router.post('/forgot-password', authController.forgotPassword);
 router.post('/reset-password', authController.resetPassword);
 
+// ----------------------------------------
+// Google OAuth routes — no JWT required
+// Purpose: Initiate and handle the Google OAuth redirect flow
+// session: false — we use JWT, not server-side sessions
+// ----------------------------------------
+
+// Redirect user to Google's consent screen
+router.get('/google', passport.authenticate('google', { session: false, scope: ['profile', 'email'] }));
+
+// Google redirects back here — Passport runs verify callback, then googleCallback signs a JWT
+router.get('/google/callback',
+    passport.authenticate('google', { session: false, failureRedirect: `${process.env.FRONTEND_URL}/login?error=oauth_failed` }),
+    authController.googleCallback
+);
+
 // Protected routes — JWT required (authMiddleware attaches req.user)
 router.get('/me', authMiddleware, authController.me);
+
+// ----------------------------------------
+// Google account link/unlink — JWT required
+// Purpose: Let existing email/password users connect or disconnect their Google account
+// ----------------------------------------
+router.post('/me/google/link', authMiddleware, authController.googleLink);
+router.delete('/me/google/link', authMiddleware, authController.googleUnlink);
 
 module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -3,6 +3,7 @@ const express = require('express');
 const cors = require('cors');
 const bodyParser = require('body-parser');
 const connectDB = require('./config/database');
+const passport = require('./config/passport');
 
 // Connect to MongoDB
 connectDB();
@@ -17,6 +18,7 @@ app.use(cors({
 }));
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: true }));
+app.use(passport.initialize());
 
 // Routes
 app.use('/api/auth', require('./routes/auth.routes'));

--- a/docs/master_planning_doc.md
+++ b/docs/master_planning_doc.md
@@ -262,7 +262,7 @@ API-1. [x] `feat: implement jwt authentication endpoints`
    - POST /api/auth/reset-password — verify token, set new password
    - Implement password validation, error handling
 
-API-2. [ ] `feat: add google oauth integration`
+API-2. [x] `feat: add google oauth integration`
    - GET /api/auth/google — initiate OAuth flow (login/register)
    - GET /api/auth/google/callback — handle OAuth callback, create/find user, return JWT
    - POST /api/me/google/link — link Google account to existing user
@@ -280,6 +280,8 @@ API-4. [ ] `feat: add note crud endpoints`
    - GET /api/notes/:id — get single note
    - PUT /api/notes/:id — update note
    - DELETE /api/notes/:id — soft delete note
+   - Note: implement keepNotes logic for DELETE /api/auth/me/google/link (deferred from API-2)
+     When keepNotes: false, delete all notes with source: 'google_docs' belonging to the user
 
 API-5. [ ] `feat: add google drive api client integration`
    - Set up Google Drive API client


### PR DESCRIPTION
## Summary
- Adds Google OAuth flow via Passport.js (register, login, auto-link by email)
- Adds googleCallback controller to sign JWT and redirect to frontend
- Adds link/unlink endpoints for existing email/password users
- Initializes Passport in server.js
- Makes password conditionally required in User model (not required for Google-only users)

## Closes
Closes #13