### PR TITLE
API-4: feat: add note crud endpoints

### DIFF
--- a/backend/controllers/auth.controller.js
+++ b/backend/controllers/auth.controller.js
@@ -1,5 +1,6 @@
 const crypto = require('crypto');
 const User = require('../models/User');
+const Note = require('../models/Note');
 const jwt = require('jsonwebtoken');
 const { Resend } = require('resend');
 
@@ -188,6 +189,17 @@ exports.googleUnlink = async (req, res) => {
     // Prevent lockout — Google-only users have no password to fall back on
     if (!req.user.password) {
         return res.status(400).json({ success: false, error: 'Set a password before unlinking Google' });
+    }
+
+    const { keepNotes = true } = req.body;
+
+    // If keepNotes is false, soft delete all notes imported from Google Docs
+    // Google Docs notes are identified by googleDocId being set on the note
+    if (!keepNotes) {
+        await Note.updateMany(
+            { userId: req.user._id, googleDocId: { $ne: null } },
+            { deletedAt: new Date() }
+        );
     }
 
     req.user.googleId = undefined;

--- a/backend/controllers/notes.controller.js
+++ b/backend/controllers/notes.controller.js
@@ -1,0 +1,141 @@
+const Note = require('../models/Note');
+
+// ============================================================
+// NOTES CONTROLLER
+// Purpose: Handle business logic for all note CRUD endpoints
+// Used by: routes/notes.routes.js
+// Endpoints: createNote, getNotes, getNoteById, updateNote, deleteNote
+// ============================================================
+
+// ----------------------------------------
+// POST /api/notes
+// Purpose: Create a new note for the authenticated user
+// ----------------------------------------
+exports.createNote = async (req, res) => {
+    const { title, content, contentType, tags, subject, folder, visibility } = req.body;
+
+    const note = await Note.create({
+        userId: req.user._id,
+        title,
+        content,
+        contentType,
+        tags,
+        subject,
+        folder,
+        visibility,
+    });
+
+    res.status(201).json({ success: true, note });
+};
+
+// ----------------------------------------
+// GET /api/notes
+// Purpose: List the authenticated user's notes with optional search, filters, and pagination
+// Query params: search, subject, folder, tags, visibility, isPinned, page, limit
+// ----------------------------------------
+exports.getNotes = async (req, res) => {
+    const { search, subject, folder, tags, visibility, isPinned, page = 1, limit = 20 } = req.query;
+
+    // Base filter — always scope to current user and exclude soft-deleted notes
+    const filter = {
+        userId: req.user._id,
+        deletedAt: null,
+    };
+
+    // Optional filters — only applied if the query param was provided
+    if (subject) filter.subject = subject;
+    if (folder) filter.folder = folder;
+    if (visibility) filter.visibility = visibility;
+    if (isPinned !== undefined) filter.isPinned = isPinned === 'true';
+    if (tags) filter.tags = { $in: Array.isArray(tags) ? tags : [tags] };
+
+    // Text search across title and content using case-insensitive regex
+    if (search) {
+        filter.$or = [
+            { title: { $regex: search, $options: 'i' } },
+            { content: { $regex: search, $options: 'i' } },
+        ];
+    }
+
+    const skip = (Number(page) - 1) * Number(limit);
+
+    const [notes, total] = await Promise.all([
+        Note.find(filter)
+            .sort({ isPinned: -1, createdAt: -1 }) // pinned notes first, then newest
+            .skip(skip)
+            .limit(Number(limit)),
+        Note.countDocuments(filter),
+    ]);
+
+    res.status(200).json({
+        success: true,
+        notes,
+        pagination: {
+            total,
+            page: Number(page),
+            limit: Number(limit),
+            pages: Math.ceil(total / Number(limit)),
+        },
+    });
+};
+
+// ----------------------------------------
+// GET /api/notes/:id
+// Purpose: Get a single note by ID — only accessible by the owner
+// ----------------------------------------
+exports.getNoteById = async (req, res) => {
+    const note = await Note.findOne({
+        _id: req.params.id,
+        userId: req.user._id,
+        deletedAt: null,
+    });
+
+    if (!note) {
+        return res.status(404).json({ success: false, error: 'Note not found' });
+    }
+
+    // Track engagement — increment view count and update last viewed timestamp
+    note.viewCount += 1;
+    note.lastViewedAt = new Date();
+    await note.save();
+
+    res.status(200).json({ success: true, note });
+};
+
+// ----------------------------------------
+// PUT /api/notes/:id
+// Purpose: Update a note — only accessible by the owner
+// ----------------------------------------
+exports.updateNote = async (req, res) => {
+    const { title, content, contentType, tags, subject, folder, visibility, sharedWith, isPinned } = req.body;
+
+    const note = await Note.findOneAndUpdate(
+        { _id: req.params.id, userId: req.user._id, deletedAt: null },
+        { title, content, contentType, tags, subject, folder, visibility, sharedWith, isPinned },
+        { new: true, runValidators: true }  // new: true returns the updated doc
+    );
+
+    if (!note) {
+        return res.status(404).json({ success: false, error: 'Note not found' });
+    }
+
+    res.status(200).json({ success: true, note });
+};
+
+// ----------------------------------------
+// DELETE /api/notes/:id
+// Purpose: Soft delete a note — sets deletedAt instead of removing from DB
+// ----------------------------------------
+exports.deleteNote = async (req, res) => {
+    const note = await Note.findOneAndUpdate(
+        { _id: req.params.id, userId: req.user._id, deletedAt: null },
+        { deletedAt: new Date() },
+        { new: true }
+    );
+
+    if (!note) {
+        return res.status(404).json({ success: false, error: 'Note not found' });
+    }
+
+    res.status(200).json({ success: true, message: 'Note deleted' });
+};

--- a/backend/routes/notes.routes.js
+++ b/backend/routes/notes.routes.js
@@ -1,0 +1,21 @@
+const express = require('express');
+const router = express.Router();
+const notesController = require('../controllers/notes.controller');
+const authMiddleware = require('../middleware/auth.middleware');
+
+// ============================================================
+// NOTES ROUTES
+// Purpose: Map HTTP endpoints to notes controller functions
+// Base path: /api/notes (mounted in server.js)
+// All routes are protected — JWT required
+// ============================================================
+
+router.use(authMiddleware);
+
+router.post('/', notesController.createNote);
+router.get('/', notesController.getNotes);
+router.get('/:id', notesController.getNoteById);
+router.put('/:id', notesController.updateNote);
+router.delete('/:id', notesController.deleteNote);
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -22,6 +22,7 @@ app.use(passport.initialize());
 
 // Routes
 app.use('/api/auth', require('./routes/auth.routes'));
+app.use('/api/notes', require('./routes/notes.routes'));
 
 // Health check endpoint
 app.get('/health', (req, res) => {

--- a/docs/master_planning_doc.md
+++ b/docs/master_planning_doc.md
@@ -274,7 +274,7 @@ API-3. [x] `feat: add jwt verification middleware`
    - Extract user from token and attach to request
    - Handle expired tokens, invalid tokens, missing tokens
 
-API-4. [ ] `feat: add note crud endpoints`
+API-4. [x] `feat: add note crud endpoints`
    - POST /api/notes — create note
    - GET /api/notes — list user's notes (with search, filters, pagination)
    - GET /api/notes/:id — get single note


### PR DESCRIPTION
## Summary
- Adds full CRUD for notes (create, list, get, update, soft delete)
- List endpoint supports search, filters (subject, folder, tags, visibility, isPinned), and pagination
- All routes protected by authMiddleware
- Implements keepNotes logic in googleUnlink — soft deletes Google Docs notes when keepNotes: false

## Closes
Closes #15