### PR TITLE
API-8: feat: implement ai flashcard generation

### DIFF
--- a/backend/controllers/flashcardSets.controller.js
+++ b/backend/controllers/flashcardSets.controller.js
@@ -1,0 +1,53 @@
+const FlashcardSet = require('../models/FlashcardSet');
+const Flashcard = require('../models/Flashcard');
+const groqService = require('../services/groq.service');
+
+// ============================================================
+// FLASHCARD SETS CONTROLLER
+// Purpose: Handle business logic for flashcard set endpoints
+// Used by: routes/flashcardSets.routes.js
+// Endpoints: generateFromContent (API-8)
+//            Full CRUD covered in API-9
+// ============================================================
+
+// ----------------------------------------
+// POST /api/flashcard-sets/generate
+// Purpose: Generate AI flashcards from raw submitted content (no note required)
+//   - Body: { content, title }
+//   - title is optional — defaults to "Generated Flashcard Set"
+//   - Creates a FlashcardSet not linked to any note (noteId: null)
+//   - Bulk inserts Flashcard docs and updates totalCards
+// Generated once — no regeneration
+// ----------------------------------------
+exports.generateFromContent = async (req, res) => {
+    const { content, title } = req.body;
+
+    if (!content || content.trim().length === 0) {
+        return res.status(400).json({ success: false, error: 'Content is required to generate flashcards' });
+    }
+
+    const result = await groqService.generateFlashcards(content);
+
+    // Create the FlashcardSet — not linked to any note
+    const set = await FlashcardSet.create({
+        userId: req.user._id,
+        noteId: null,
+        title: title?.trim() || 'Generated Flashcard Set',
+        isAIGenerated: true,
+        generatedAt: new Date(),
+        totalCards: result.cards.length,
+    });
+
+    // Bulk insert all flashcard docs
+    const flashcardDocs = result.cards.map((card, index) => ({
+        setId: set._id,
+        front: card.front,
+        back: card.back,
+        order: index,
+    }));
+    await Flashcard.insertMany(flashcardDocs);
+
+    const populatedSet = await FlashcardSet.findById(set._id).populate('flashcards');
+
+    res.status(201).json({ success: true, set: populatedSet });
+};

--- a/backend/controllers/notes.controller.js
+++ b/backend/controllers/notes.controller.js
@@ -1,4 +1,6 @@
 const Note = require('../models/Note');
+const FlashcardSet = require('../models/FlashcardSet');
+const Flashcard = require('../models/Flashcard');
 const getGoogleDriveClient = require('../config/googleDrive');
 const cloudinary = require('../config/cloudinary');
 const groqService = require('../services/groq.service');
@@ -317,4 +319,57 @@ exports.generateSummary = async (req, res) => {
     );
 
     res.status(200).json({ success: true, note: updatedNote, cached: false });
+};
+
+// ----------------------------------------
+// POST /api/notes/:id/flashcards/generate
+// Purpose: Generate AI flashcards from an existing note's content
+//   - Uses note.content as input to Groq
+//   - Creates a FlashcardSet linked to the note (isAIGenerated: true)
+//   - Bulk inserts Flashcard docs and updates totalCards
+//   - Sets note.hasFlashcards = true
+// Generated once — no regeneration (call the endpoint again to create a new set)
+// ----------------------------------------
+exports.generateFlashcardsFromNote = async (req, res) => {
+    const note = await Note.findOne({
+        _id: req.params.id,
+        userId: req.user._id,
+        deletedAt: null,
+    });
+
+    if (!note) {
+        return res.status(404).json({ success: false, error: 'Note not found' });
+    }
+
+    if (!note.content || note.content.trim().length === 0) {
+        return res.status(400).json({ success: false, error: 'Note has no content to generate flashcards from' });
+    }
+
+    const result = await groqService.generateFlashcards(note.content);
+
+    // Create the FlashcardSet linked to this note
+    const set = await FlashcardSet.create({
+        userId: req.user._id,
+        noteId: note._id,
+        title: note.title ? `${note.title} — Flashcards` : 'Generated Flashcard Set',
+        isAIGenerated: true,
+        generatedAt: new Date(),
+        totalCards: result.cards.length,
+    });
+
+    // Bulk insert all flashcard docs
+    const flashcardDocs = result.cards.map((card, index) => ({
+        setId: set._id,
+        front: card.front,
+        back: card.back,
+        order: index,
+    }));
+    await Flashcard.insertMany(flashcardDocs);
+
+    // Mark note as having flashcards
+    await Note.findByIdAndUpdate(note._id, { hasFlashcards: true });
+
+    const populatedSet = await FlashcardSet.findById(set._id).populate('flashcards');
+
+    res.status(201).json({ success: true, set: populatedSet });
 };

--- a/backend/routes/flashcardSets.routes.js
+++ b/backend/routes/flashcardSets.routes.js
@@ -1,0 +1,19 @@
+const express = require('express');
+const router = express.Router();
+const flashcardSetsController = require('../controllers/flashcardSets.controller');
+const authMiddleware = require('../middleware/auth.middleware');
+
+// ============================================================
+// FLASHCARD SETS ROUTES
+// Purpose: Map HTTP endpoints to flashcard set controller functions
+// Base path: /api/flashcard-sets (mounted in server.js)
+// All routes are protected — JWT required
+// Note: static routes (/generate) must be defined before dynamic routes (/:id)
+// ============================================================
+
+router.use(authMiddleware);
+
+// AI generation routes (static — before /:id)
+router.post('/generate', flashcardSetsController.generateFromContent);
+
+module.exports = router;

--- a/backend/routes/notes.routes.js
+++ b/backend/routes/notes.routes.js
@@ -27,5 +27,6 @@ router.delete('/:id', notesController.deleteNote);
 
 // AI routes
 router.post('/:id/summary', notesController.generateSummary);
+router.post('/:id/flashcards/generate', notesController.generateFlashcardsFromNote);
 
 module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -24,6 +24,7 @@ app.use(passport.initialize());
 app.use('/api/auth', require('./routes/auth.routes'));
 app.use('/api/notes', require('./routes/notes.routes'));
 app.use('/api/google', require('./routes/google.routes'));
+app.use('/api/flashcard-sets', require('./routes/flashcardSets.routes'));
 
 // Health check endpoint
 app.get('/health', (req, res) => {

--- a/backend/services/groq.service.js
+++ b/backend/services/groq.service.js
@@ -65,4 +65,60 @@ ${content}`;
     };
 };
 
-module.exports = { generateSummary };
+// ----------------------------------------
+// generateFlashcards
+// Purpose: Extract Q&A flashcard pairs from note or document content
+// Returns: { cards: [{ front, back }], model, tokenCount }
+//
+// Cards are capped at 20 per generation
+// front — a question, term, or concept prompt
+// back  — the answer, definition, or explanation
+// ----------------------------------------
+const generateFlashcards = async (content) => {
+    const systemPrompt = `You are a study assistant helping college students create flashcards from their academic notes and documents.
+Your job is to identify the most important concepts, terms, and ideas and turn them into effective flashcard Q&A pairs.
+Write questions that test understanding, not just memorization.
+Never make up information — only use what is present in the provided content.`;
+
+    const userPrompt = `Create flashcards from the following content. Return your response as a valid JSON array of objects with exactly these two fields per card:
+
+[
+  { "front": "A clear question, term, or concept prompt", "back": "The answer, definition, or explanation" },
+  ...
+]
+
+Rules:
+- Generate between 5 and 20 cards depending on how much content there is
+- Prioritize key terms, definitions, formulas, and important concepts
+- Write "front" as a question (e.g. "What is X?" or "Define Y") or a term to define
+- Write "back" as a concise but complete answer (1-3 sentences max)
+- Do not create duplicate or near-duplicate cards
+- Only return the JSON array. No extra text, no markdown code blocks.
+
+Content:
+${content}`;
+
+    const response = await groq.chat.completions.create({
+        model: MODEL,
+        messages: [
+            { role: 'system', content: systemPrompt },
+            { role: 'user', content: userPrompt },
+        ],
+        temperature: 0.3,
+        max_tokens: 2000,
+    });
+
+    const raw = response.choices[0].message.content.trim();
+    const tokenCount = response.usage?.total_tokens ?? null;
+
+    const cleaned = raw.replace(/^```json\s*/i, '').replace(/```\s*$/, '').trim();
+    const cards = JSON.parse(cleaned);
+
+    return {
+        cards,
+        model: MODEL,
+        tokenCount,
+    };
+};
+
+module.exports = { generateSummary, generateFlashcards };

--- a/docs/master_planning_doc.md
+++ b/docs/master_planning_doc.md
@@ -310,19 +310,30 @@ API-7. [x] `feat: integrate groq api for summary generation`
    - POST /api/notes/:id/summary — generate AI summary
    - See [Groq AI Integration](./backend/groq_ai_integration.md)
 
-API-8. [ ] `feat: implement ai flashcard generation`
-   - Create prompt templates for flashcard extraction
-   - POST /api/notes/:id/flashcards/generate — generate flashcards from note
-   - Parse AI response into flashcard format
+API-8. [x] `feat: implement ai flashcard generation`
+   - Add `generateFlashcards(content)` to services/groq.service.js
+     - Prompt extracts Q&A pairs from content, returns JSON array: [{ front, back }]
+     - Cap at 20 cards per generation
+   - Two generation sources — both create a FlashcardSet + Flashcard docs, generated once (no regeneration):
+     - POST /api/notes/:id/flashcards/generate — generate from an existing note
+       - Uses note.content as input
+       - FlashcardSet linked to noteId, isAIGenerated: true
+       - Sets note.hasFlashcards = true
+     - POST /api/flashcard-sets/generate — generate from raw submitted content
+       - Body: { content, title } — user pastes or submits document text
+       - FlashcardSet not linked to any note (noteId: null), isAIGenerated: true
+   - Both endpoints: create FlashcardSet → bulk insert Flashcard docs → update totalCards
 
 API-9. [ ] `feat: add flashcard set and flashcard crud endpoints`
-   - POST /api/flashcard-sets — create set
-   - GET /api/flashcard-sets — list user's sets
-   - GET /api/flashcard-sets/:id — get set with flashcards
-   - POST /api/flashcard-sets/:id/cards — add card
-   - PUT /api/flashcard-sets/:setId/cards/:cardId — update card
-   - PUT /api/flashcard-sets/:setId/cards/:cardId/progress — update study progress
+   - Manual set/card management (user-created, not AI):
+   - POST /api/flashcard-sets — create a set manually (noteId optional)
+   - GET /api/flashcard-sets — list user's sets (includes AI-generated and manual)
+   - GET /api/flashcard-sets/:id — get set with flashcards populated
+   - POST /api/flashcard-sets/:id/cards — add a card to a set
+   - PUT /api/flashcard-sets/:setId/cards/:cardId — update a card (front/back)
+   - PUT /api/flashcard-sets/:setId/cards/:cardId/progress — update study progress (correct/incorrect/confidence)
    - DELETE /api/flashcard-sets/:id — soft delete set
+   - DELETE /api/flashcard-sets/:setId/cards/:cardId — soft delete card
 
 API-10. [ ] `feat: implement task crud endpoints`
    - POST /api/tasks — create task (with optional note linking)


### PR DESCRIPTION
## Summary
- Added `generateFlashcards(content)` to `services/groq.service.js` (shared by both endpoints)
- `POST /api/notes/:id/flashcards/generate` — generates flashcards from an existing note's content; creates a FlashcardSet linked to the note, sets `note.hasFlashcards = true`
- `POST /api/flashcard-sets/generate` — generates flashcards from raw submitted content (no note required); title optional, defaults to "Generated Flashcard Set"

Closes #19