### PR TITLE
API-10: feat: implement task crud endpoints

### DIFF
--- a/backend/controllers/tasks.controller.js
+++ b/backend/controllers/tasks.controller.js
@@ -1,0 +1,183 @@
+const Task = require('../models/Task');
+
+// ============================================================
+// TASKS CONTROLLER
+// Purpose: Handle business logic for all task CRUD endpoints
+// Used by: routes/tasks.routes.js
+// Endpoints: createTask, getTasks, getTaskById, updateTask,
+//            updateStatus, deleteTask
+// ============================================================
+
+// ----------------------------------------
+// POST /api/tasks
+// Purpose: Create a new task for the authenticated user
+// Body: { title, dueDate (required), type, priority, description?,
+//         noteId?, duration?, reminderMinutes?, recurrence? }
+// ----------------------------------------
+exports.createTask = async (req, res) => {
+    const {
+        title,
+        dueDate,
+        type,
+        priority,
+        description,
+        noteId,
+        duration,
+        reminderMinutes,
+        recurrence,
+    } = req.body;
+
+    if (!dueDate) {
+        return res.status(400).json({ success: false, error: 'dueDate is required' });
+    }
+
+    const task = await Task.create({
+        userId: req.user._id,
+        title,
+        dueDate,
+        type,
+        priority,
+        description,
+        noteId: noteId || null,
+        duration,
+        reminderMinutes,
+        recurrence,
+    });
+
+    res.status(201).json({ success: true, task });
+};
+
+// ----------------------------------------
+// GET /api/tasks
+// Purpose: List the authenticated user's tasks with optional filters
+// Query params: status, type, priority, startDate, endDate
+// Sorted by dueDate ascending (soonest first)
+// ----------------------------------------
+exports.getTasks = async (req, res) => {
+    const { status, type, priority, startDate, endDate } = req.query;
+
+    const filter = {
+        userId: req.user._id,
+        deletedAt: null,
+    };
+
+    if (status) filter.status = status;
+    if (type) filter.type = type;
+    if (priority) filter.priority = priority;
+
+    // Date range filter on dueDate
+    if (startDate || endDate) {
+        filter.dueDate = {};
+        if (startDate) filter.dueDate.$gte = new Date(startDate);
+        if (endDate) filter.dueDate.$lte = new Date(endDate);
+    }
+
+    const tasks = await Task.find(filter).sort({ dueDate: 1 });
+
+    res.status(200).json({ success: true, tasks });
+};
+
+// ----------------------------------------
+// GET /api/tasks/:id
+// Purpose: Get a single task by ID — only accessible by the owner
+// ----------------------------------------
+exports.getTaskById = async (req, res) => {
+    const task = await Task.findOne({
+        _id: req.params.id,
+        userId: req.user._id,
+        deletedAt: null,
+    });
+
+    if (!task) {
+        return res.status(404).json({ success: false, error: 'Task not found' });
+    }
+
+    res.status(200).json({ success: true, task });
+};
+
+// ----------------------------------------
+// PUT /api/tasks/:id
+// Purpose: Update a task's fields (title, description, dueDate, type, priority, etc.)
+// Does NOT handle status changes — use PATCH /:id/status for that
+// Uses findOneAndUpdate (no hook needed for non-status updates)
+// ----------------------------------------
+exports.updateTask = async (req, res) => {
+    const {
+        title,
+        description,
+        dueDate,
+        type,
+        priority,
+        noteId,
+        duration,
+        reminderMinutes,
+        recurrence,
+    } = req.body;
+
+    const task = await Task.findOneAndUpdate(
+        { _id: req.params.id, userId: req.user._id, deletedAt: null },
+        { title, description, dueDate, type, priority, noteId, duration, reminderMinutes, recurrence },
+        { new: true, runValidators: true }
+    );
+
+    if (!task) {
+        return res.status(404).json({ success: false, error: 'Task not found' });
+    }
+
+    res.status(200).json({ success: true, task });
+};
+
+// ----------------------------------------
+// PATCH /api/tasks/:id/status
+// Purpose: Quick status update — triggers pre-save hook
+//   - Hook auto-sets completedAt when status → 'completed'
+//   - Hook auto-clears completedAt when status moves back to 'todo'/'in_progress'
+//   - Hook creates next recurring task occurrence when completed
+// Must use .save() (not findOneAndUpdate) to fire the pre-save hook
+// ----------------------------------------
+exports.updateStatus = async (req, res) => {
+    const { status } = req.body;
+
+    const validStatuses = ['todo', 'in_progress', 'completed'];
+    if (!status || !validStatuses.includes(status)) {
+        return res.status(400).json({
+            success: false,
+            error: `status must be one of: ${validStatuses.join(', ')}`,
+        });
+    }
+
+    const task = await Task.findOne({
+        _id: req.params.id,
+        userId: req.user._id,
+        deletedAt: null,
+    });
+
+    if (!task) {
+        return res.status(404).json({ success: false, error: 'Task not found' });
+    }
+
+    // Set the new status and call .save() to trigger the pre-save hook
+    // The hook will: set completedAt if completed, generate next recurrence if recurring
+    task.status = status;
+    await task.save();
+
+    res.status(200).json({ success: true, task });
+};
+
+// ----------------------------------------
+// DELETE /api/tasks/:id
+// Purpose: Soft delete a task — sets deletedAt instead of removing from DB
+// ----------------------------------------
+exports.deleteTask = async (req, res) => {
+    const task = await Task.findOneAndUpdate(
+        { _id: req.params.id, userId: req.user._id, deletedAt: null },
+        { deletedAt: new Date() },
+        { new: true }
+    );
+
+    if (!task) {
+        return res.status(404).json({ success: false, error: 'Task not found' });
+    }
+
+    res.status(200).json({ success: true, message: 'Task deleted' });
+};

--- a/backend/routes/tasks.routes.js
+++ b/backend/routes/tasks.routes.js
@@ -1,0 +1,24 @@
+const express = require('express');
+const router = express.Router();
+const tasksController = require('../controllers/tasks.controller');
+const authMiddleware = require('../middleware/auth.middleware');
+
+// ============================================================
+// TASKS ROUTES
+// Purpose: Map HTTP endpoints to tasks controller functions
+// Base path: /api/tasks (mounted in server.js)
+// All routes are protected — JWT required
+// Note: static routes (/:id/status) defined before dynamic /:id
+//       to avoid Express treating "status" as a task ID
+// ============================================================
+
+router.use(authMiddleware);
+
+router.post('/', tasksController.createTask);
+router.get('/', tasksController.getTasks);
+router.get('/:id', tasksController.getTaskById);
+router.put('/:id', tasksController.updateTask);
+router.patch('/:id/status', tasksController.updateStatus);
+router.delete('/:id', tasksController.deleteTask);
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -25,6 +25,7 @@ app.use('/api/auth', require('./routes/auth.routes'));
 app.use('/api/notes', require('./routes/notes.routes'));
 app.use('/api/google', require('./routes/google.routes'));
 app.use('/api/flashcard-sets', require('./routes/flashcardSets.routes'));
+app.use('/api/tasks', require('./routes/tasks.routes'));
 
 // Health check endpoint
 app.get('/health', (req, res) => {

--- a/docs/master_planning_doc.md
+++ b/docs/master_planning_doc.md
@@ -324,7 +324,7 @@ API-8. [x] `feat: implement ai flashcard generation`
        - FlashcardSet not linked to any note (noteId: null), isAIGenerated: true
    - Both endpoints: create FlashcardSet → bulk insert Flashcard docs → update totalCards
 
-API-9. [ ] `feat: add flashcard set and flashcard crud endpoints`
+API-9. [x] `feat: add flashcard set and flashcard crud endpoints`
    - Manual set/card management (user-created, not AI):
    - POST /api/flashcard-sets — create a set manually (noteId optional)
    - GET /api/flashcard-sets — list user's sets (includes AI-generated and manual)
@@ -335,7 +335,7 @@ API-9. [ ] `feat: add flashcard set and flashcard crud endpoints`
    - DELETE /api/flashcard-sets/:id — soft delete set
    - DELETE /api/flashcard-sets/:setId/cards/:cardId — soft delete card
 
-API-10. [ ] `feat: implement task crud endpoints`
+API-10. [x] `feat: implement task crud endpoints`
    - POST /api/tasks — create task (with optional note linking)
    - GET /api/tasks — list tasks (with status filters, date range)
    - PUT /api/tasks/:id — update task


### PR DESCRIPTION
## Summary
- Full task CRUD: create, list (with filters), get by ID, update, soft delete
- `PATCH /api/tasks/:id/status` uses `.save()` to fire the pre-save hook — auto-sets `completedAt` on completion, auto-generates next recurring task occurrence
- `PUT /api/tasks/:id` uses `findOneAndUpdate` for non-status field updates
- `GET /api/tasks` supports filtering by `status`, `type`, `priority`, `startDate`, `endDate`; sorted by `dueDate` ascending

Closes #21