### PR TITLE
API-11: feat: create calendar aggregation endpoint

### DIFF
--- a/backend/controllers/calendar.controller.js
+++ b/backend/controllers/calendar.controller.js
@@ -1,0 +1,90 @@
+const Task = require('../models/Task');
+
+// ============================================================
+// CALENDAR CONTROLLER
+// Purpose: Aggregate tasks for calendar rendering
+// Used by: routes/calendar.routes.js
+// Endpoints: getCalendar
+// ============================================================
+
+// ----------------------------------------
+// GET /api/calendar
+// Purpose: Aggregate owned + shared tasks by date range for calendar rendering
+// Query params:
+//   from (required) — start date, ISO 8601
+//   to   (required) — end date, ISO 8601 (inclusive, extended to 23:59:59)
+//   view (optional) — 'week' | 'month' — returned in response meta only
+// Response:
+//   days    — tasks grouped by YYYY-MM-DD key (owned + participated)
+//   overdue — all tasks past due + not completed (regardless of range)
+// ----------------------------------------
+exports.getCalendar = async (req, res) => {
+    const { from, to, view } = req.query;
+
+    if (!from || !to) {
+        return res.status(400).json({
+            success: false,
+            error: 'from and to query params are required (ISO 8601)',
+        });
+    }
+
+    const fromDate = new Date(from);
+    const toDate = new Date(to);
+
+    if (isNaN(fromDate) || isNaN(toDate)) {
+        return res.status(400).json({
+            success: false,
+            error: 'from and to must be valid ISO 8601 dates',
+        });
+    }
+
+    // Extend toDate to end of day so tasks due on that day are included
+    toDate.setHours(23, 59, 59, 999);
+
+    const userId = req.user._id;
+    const now = new Date();
+
+    // Owned tasks in date range
+    const ownedTasks = await Task.find({
+        userId,
+        deletedAt: null,
+        dueDate: { $gte: fromDate, $lte: toDate },
+    }).sort({ dueDate: 1 });
+
+    // Shared tasks user is a participant in (exclude owned to avoid duplication)
+    const participantTasks = await Task.find({
+        isShared: true,
+        'participants.userId': userId,
+        userId: { $ne: userId },
+        deletedAt: null,
+        dueDate: { $gte: fromDate, $lte: toDate },
+    }).sort({ dueDate: 1 });
+
+    // Group all in-range tasks by YYYY-MM-DD
+    const days = {};
+    for (const task of [...ownedTasks, ...participantTasks]) {
+        const dateKey = task.dueDate.toISOString().split('T')[0];
+        if (!days[dateKey]) days[dateKey] = [];
+        days[dateKey].push(task);
+    }
+
+    // Overdue: past due, not completed, not deleted — owned + participated
+    const overdue = await Task.find({
+        $or: [
+            { userId },
+            { isShared: true, 'participants.userId': userId },
+        ],
+        deletedAt: null,
+        status: { $ne: 'completed' },
+        dueDate: { $lt: now },
+    }).sort({ dueDate: 1 });
+
+    res.status(200).json({
+        success: true,
+        view: view || null,
+        from: fromDate,
+        to: toDate,
+        days,
+        overdue,
+    });
+};

--- a/backend/routes/calendar.routes.js
+++ b/backend/routes/calendar.routes.js
@@ -1,0 +1,17 @@
+const express = require('express');
+const router = express.Router();
+const calendarController = require('../controllers/calendar.controller');
+const authMiddleware = require('../middleware/auth.middleware');
+
+// ============================================================
+// CALENDAR ROUTES
+// Purpose: Map HTTP endpoints to calendar controller functions
+// Base path: /api/calendar (mounted in server.js)
+// All routes are protected — JWT required
+// ============================================================
+
+router.use(authMiddleware);
+
+router.get('/', calendarController.getCalendar);
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -26,6 +26,7 @@ app.use('/api/notes', require('./routes/notes.routes'));
 app.use('/api/google', require('./routes/google.routes'));
 app.use('/api/flashcard-sets', require('./routes/flashcardSets.routes'));
 app.use('/api/tasks', require('./routes/tasks.routes'));
+app.use('/api/calendar', require('./routes/calendar.routes'));
 
 // Health check endpoint
 app.get('/health', (req, res) => {

--- a/docs/master_planning_doc.md
+++ b/docs/master_planning_doc.md
@@ -342,7 +342,7 @@ API-10. [x] `feat: implement task crud endpoints`
    - DELETE /api/tasks/:id — soft delete task
    - PATCH /api/tasks/:id/status — quick status update
 
-API-11. [ ] `feat: create calendar aggregation endpoint`
+API-11. [x] `feat: create calendar aggregation endpoint`
    - GET /api/calendar — aggregate tasks by date range
    - Support week and month views
    - Include overdue task detection


### PR DESCRIPTION
## Summary
- Adds `GET /api/calendar` endpoint that aggregates tasks for calendar rendering
- Groups owned and shared (participated) tasks by `YYYY-MM-DD` date key within the requested `from`/`to` range
- Returns `overdue` array: all non-completed tasks past due across owned and participated tasks

Closes #22