### PR TITLE
API-16: feat: add resume upload and AI feedback endpoints

### DIFF
--- a/backend/controllers/resumes.controller.js
+++ b/backend/controllers/resumes.controller.js
@@ -1,0 +1,156 @@
+const pdfParse = require('pdf-parse');
+const Resume = require('../models/Resume');
+const cloudinary = require('../config/cloudinary');
+const groqService = require('../services/groq.service');
+
+// ============================================================
+// RESUMES CONTROLLER
+// Purpose: Handle business logic for resume upload and AI feedback endpoints
+// Used by: routes/resumes.routes.js
+// Endpoints: uploadResume, getResumes, generateFeedback, getFeedback
+// ============================================================
+
+// ----------------------------------------
+// Helper: uploadBufferToCloudinary
+// Purpose: Upload an in-memory buffer to Cloudinary
+// Used instead of stream pipe because multer memoryStorage gives us a buffer, not a stream
+// ----------------------------------------
+const uploadBufferToCloudinary = (buffer, fileName) => {
+    return new Promise((resolve, reject) => {
+        const uploadStream = cloudinary.uploader.upload_stream(
+            {
+                folder: 'continuum/resumes',
+                public_id: fileName.replace(/\.[^.]+$/, ''), // strip extension
+                resource_type: 'raw',
+                format: 'pdf',
+                overwrite: false, // each upload is a new version
+            },
+            (error, result) => {
+                if (error) return reject(error);
+                resolve(result);
+            }
+        );
+        uploadStream.end(buffer);
+    });
+};
+
+// ----------------------------------------
+// POST /api/resumes/upload
+// Purpose: Upload a resume PDF — parse text with pdf-parse, upload file to Cloudinary,
+//          save Resume doc with extractedText cached for instant AI feedback later
+// Body: multipart/form-data — field name: "resume"
+// Optional body fields: version, targetRole
+// ----------------------------------------
+exports.uploadResume = async (req, res) => {
+    if (!req.file) {
+        return res.status(400).json({ success: false, error: 'A PDF file is required' });
+    }
+
+    const { version, targetRole } = req.body;
+
+    // Extract plain text from PDF buffer — cached so AI feedback is instant later
+    const pdfData = await pdfParse(req.file.buffer);
+    const extractedText = pdfData.text;
+
+    if (!extractedText || extractedText.trim().length === 0) {
+        return res.status(400).json({ success: false, error: 'Could not extract text from PDF — ensure the file is not scanned/image-only' });
+    }
+
+    // Upload to Cloudinary
+    const cloudinaryResult = await uploadBufferToCloudinary(req.file.buffer, req.file.originalname);
+
+    const resume = await Resume.create({
+        userId: req.user._id,
+        fileName: req.file.originalname,
+        fileUrl: cloudinaryResult.secure_url,
+        fileSize: req.file.size,
+        mimeType: req.file.mimetype,
+        version: version || null,
+        targetRole: targetRole || null,
+        extractedText,
+        uploadedAt: new Date(),
+    });
+
+    // Return resume without extractedText (select: false keeps it out of the response)
+    const resumeResponse = await Resume.findById(resume._id);
+    res.status(201).json({ success: true, resume: resumeResponse });
+};
+
+// ----------------------------------------
+// GET /api/resumes
+// Purpose: List the authenticated user's resumes, newest first
+// Note: extractedText has select: false — not returned here (large field, only needed for AI)
+// ----------------------------------------
+exports.getResumes = async (req, res) => {
+    const resumes = await Resume.find({
+        userId: req.user._id,
+        deletedAt: null,
+    }).sort({ createdAt: -1 });
+
+    res.status(200).json({ success: true, resumes });
+};
+
+// ----------------------------------------
+// POST /api/resumes/:id/feedback
+// Purpose: Generate AI feedback for a resume using Groq
+//   - Re-fetches resume with +extractedText (select: false by default)
+//   - Calls Groq with the cached text
+//   - Pushes new feedback entry onto resume.feedback[]
+// ----------------------------------------
+exports.generateFeedback = async (req, res) => {
+    // Re-fetch with extractedText — select: false means normal findById won't include it
+    const resume = await Resume.findOne({
+        _id: req.params.id,
+        userId: req.user._id,
+        deletedAt: null,
+    }).select('+extractedText');
+
+    if (!resume) {
+        return res.status(404).json({ success: false, error: 'Resume not found' });
+    }
+
+    if (!resume.extractedText || resume.extractedText.trim().length === 0) {
+        return res.status(400).json({ success: false, error: 'No extracted text available for this resume' });
+    }
+
+    const result = await groqService.generateResumeFeedback(resume.extractedText);
+
+    // Push new feedback entry onto the embedded array
+    const updated = await Resume.findByIdAndUpdate(
+        resume._id,
+        {
+            $push: {
+                feedback: {
+                    overallScore: result.overallScore,
+                    strengths: result.strengths,
+                    improvements: result.improvements,
+                    sections: result.sections,
+                    keywordOptimization: result.keywordOptimization,
+                    model: result.model,
+                    generatedAt: new Date(),
+                },
+            },
+        },
+        { new: true }
+    );
+
+    res.status(200).json({ success: true, feedback: updated.feedback[updated.feedback.length - 1], resume: updated });
+};
+
+// ----------------------------------------
+// GET /api/resumes/:id/feedback
+// Purpose: Return all feedback entries for a resume
+// ----------------------------------------
+exports.getFeedback = async (req, res) => {
+    const resume = await Resume.findOne({
+        _id: req.params.id,
+        userId: req.user._id,
+        deletedAt: null,
+    });
+
+    if (!resume) {
+        return res.status(404).json({ success: false, error: 'Resume not found' });
+    }
+
+    res.status(200).json({ success: true, feedback: resume.feedback });
+};

--- a/backend/middleware/upload.middleware.js
+++ b/backend/middleware/upload.middleware.js
@@ -1,0 +1,29 @@
+const multer = require('multer');
+
+// ============================================================
+// UPLOAD MIDDLEWARE
+// Purpose: Configure multer for in-memory file uploads
+// Used by: routes/resumes.routes.js (resume PDF uploads)
+// Strategy: memoryStorage — file buffer available as req.file.buffer
+//           for immediate piping to Cloudinary and parsing with pdf-parse
+// ============================================================
+
+const storage = multer.memoryStorage();
+
+const fileFilter = (req, file, cb) => {
+    if (file.mimetype === 'application/pdf') {
+        cb(null, true);
+    } else {
+        cb(new Error('Only PDF files are allowed'), false);
+    }
+};
+
+const upload = multer({
+    storage,
+    fileFilter,
+    limits: {
+        fileSize: 10 * 1024 * 1024, // 10 MB
+    },
+});
+
+module.exports = upload;

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -20,8 +20,10 @@
         "jsonwebtoken": "^9.0.3",
         "mongodb": "^7.0.0",
         "mongoose": "^9.1.4",
+        "multer": "^2.1.0",
         "passport": "^0.7.0",
         "passport-google-oauth20": "^2.0.0",
+        "pdf-parse": "^2.4.5",
         "resend": "^6.9.2"
       }
     },
@@ -49,6 +51,190 @@
       "license": "MIT",
       "dependencies": {
         "sparse-bitfield": "^3.0.3"
+      }
+    },
+    "node_modules/@napi-rs/canvas": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.80.tgz",
+      "integrity": "sha512-DxuT1ClnIPts1kQx8FBmkk4BQDTfI5kIzywAaMjQSXfNnra5UFU9PwurXrl+Je3bJ6BGsp/zmshVVFbCmyI+ww==",
+      "license": "MIT",
+      "workspaces": [
+        "e2e/*"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas-android-arm64": "0.1.80",
+        "@napi-rs/canvas-darwin-arm64": "0.1.80",
+        "@napi-rs/canvas-darwin-x64": "0.1.80",
+        "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.80",
+        "@napi-rs/canvas-linux-arm64-gnu": "0.1.80",
+        "@napi-rs/canvas-linux-arm64-musl": "0.1.80",
+        "@napi-rs/canvas-linux-riscv64-gnu": "0.1.80",
+        "@napi-rs/canvas-linux-x64-gnu": "0.1.80",
+        "@napi-rs/canvas-linux-x64-musl": "0.1.80",
+        "@napi-rs/canvas-win32-x64-msvc": "0.1.80"
+      }
+    },
+    "node_modules/@napi-rs/canvas-android-arm64": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.80.tgz",
+      "integrity": "sha512-sk7xhN/MoXeuExlggf91pNziBxLPVUqF2CAVnB57KLG/pz7+U5TKG8eXdc3pm0d7Od0WreB6ZKLj37sX9muGOQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-arm64": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.80.tgz",
+      "integrity": "sha512-O64APRTXRUiAz0P8gErkfEr3lipLJgM6pjATwavZ22ebhjYl/SUbpgM0xcWPQBNMP1n29afAC/Us5PX1vg+JNQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-x64": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.80.tgz",
+      "integrity": "sha512-FqqSU7qFce0Cp3pwnTjVkKjjOtxMqRe6lmINxpIZYaZNnVI0H5FtsaraZJ36SiTHNjZlUB69/HhxNDT1Aaa9vA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.80.tgz",
+      "integrity": "sha512-eyWz0ddBDQc7/JbAtY4OtZ5SpK8tR4JsCYEZjCE3dI8pqoWUC8oMwYSBGCYfsx2w47cQgQCgMVRVTFiiO38hHQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.80.tgz",
+      "integrity": "sha512-qwA63t8A86bnxhuA/GwOkK3jvb+XTQaTiVML0vAWoHyoZYTjNs7BzoOONDgTnNtr8/yHrq64XXzUoLqDzU+Uuw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-musl": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.80.tgz",
+      "integrity": "sha512-1XbCOz/ymhj24lFaIXtWnwv/6eFHXDrjP0jYkc6iHQ9q8oXKzUX1Lc6bu+wuGiLhGh2GS/2JlfORC5ZcXimRcg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.80.tgz",
+      "integrity": "sha512-XTzR125w5ZMs0lJcxRlS1K3P5RaZ9RmUsPtd1uGt+EfDyYMu4c6SEROYsxyatbbu/2+lPe7MPHOO/0a0x7L/gw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-gnu": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.80.tgz",
+      "integrity": "sha512-BeXAmhKg1kX3UCrJsYbdQd3hIMDH/K6HnP/pG2LuITaXhXBiNdh//TVVVVCBbJzVQaV5gK/4ZOCMrQW9mvuTqA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-musl": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.80.tgz",
+      "integrity": "sha512-x0XvZWdHbkgdgucJsRxprX/4o4sEed7qo9rCQA9ugiS9qE2QvP0RIiEugtZhfLH3cyI+jIRFJHV4Fuz+1BHHMg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-x64-msvc": {
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.80.tgz",
+      "integrity": "sha512-Z8jPsM6df5V8B1HrCHB05+bDiCxjE9QA//3YrkKIdVDEwn5RKaqOxCJDRJkl48cJbylcrJbW4HxZbTte8juuPg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -171,6 +357,12 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/append-field": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+      "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
+      "license": "MIT"
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -284,6 +476,23 @@
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT"
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
+    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -362,6 +571,21 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "engines": [
+        "node >= 6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
       }
     },
     "node_modules/content-disposition": {
@@ -1504,6 +1728,68 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/multer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.1.0.tgz",
+      "integrity": "sha512-TBm6j41rxNohqawsxlsWsNNh/VdV4QFXcBvRcPhXaA05EZ79z0qJ2bQFpync6JBoHTeNY5Q1JpG7AlTjdlfAEA==",
+      "license": "MIT",
+      "dependencies": {
+        "append-field": "^1.0.0",
+        "busboy": "^1.6.0",
+        "concat-stream": "^2.0.0",
+        "type-is": "^1.6.18"
+      },
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/multer/node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/multer/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/multer/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/multer/node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/negotiator": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
@@ -1712,6 +1998,38 @@
       "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
       "integrity": "sha512-KG8UEiEVkR3wGEb4m5yZkVCzigAD+cVEJck2CzYZO37ZGJfctvVptVO192MwrtPhzONn6go8ylnOdMhKqi4nfg=="
     },
+    "node_modules/pdf-parse": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/pdf-parse/-/pdf-parse-2.4.5.tgz",
+      "integrity": "sha512-mHU89HGh7v+4u2ubfnevJ03lmPgQ5WU4CxAVmTSh/sxVTEDYd1er/dKS/A6vg77NX47KTEoihq8jZBLr8Cxuwg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@napi-rs/canvas": "0.1.80",
+        "pdfjs-dist": "5.4.296"
+      },
+      "bin": {
+        "pdf-parse": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.16.0 <21 || >=22.3.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/mehmet-kozan"
+      }
+    },
+    "node_modules/pdfjs-dist": {
+      "version": "5.4.296",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-5.4.296.tgz",
+      "integrity": "sha512-DlOzet0HO7OEnmUmB6wWGJrrdvbyJKftI1bhMitK7O2N8W2gc757yyYBbINy9IDafXAV9wmKr9t7xsTaNKRG5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20.16.0 || >=22.3.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas": "^0.1.80"
+      }
+    },
     "node_modules/postal-mime": {
       "version": "2.7.3",
       "resolved": "https://registry.npmjs.org/postal-mime/-/postal-mime-2.7.3.tgz",
@@ -1777,6 +2095,20 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/resend": {
@@ -2059,6 +2391,23 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/string-width": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
@@ -2200,6 +2549,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "license": "MIT"
+    },
     "node_modules/uid2": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.4.tgz",
@@ -2226,6 +2581,12 @@
       "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
       "integrity": "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==",
       "license": "BSD"
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -23,8 +23,10 @@
     "jsonwebtoken": "^9.0.3",
     "mongodb": "^7.0.0",
     "mongoose": "^9.1.4",
+    "multer": "^2.1.0",
     "passport": "^0.7.0",
     "passport-google-oauth20": "^2.0.0",
+    "pdf-parse": "^2.4.5",
     "resend": "^6.9.2"
   }
 }

--- a/backend/routes/resumes.routes.js
+++ b/backend/routes/resumes.routes.js
@@ -1,0 +1,23 @@
+const express = require('express');
+const router = express.Router();
+const resumesController = require('../controllers/resumes.controller');
+const authMiddleware = require('../middleware/auth.middleware');
+const upload = require('../middleware/upload.middleware');
+
+// ============================================================
+// RESUMES ROUTES
+// Purpose: Map HTTP endpoints to resumes controller functions
+// Base path: /api/resumes (mounted in server.js)
+// All routes are protected — JWT required
+// Note: static routes (/upload, /:id/feedback) defined before /:id
+// ============================================================
+
+router.use(authMiddleware);
+
+// upload.single('resume') — expects a single file in the "resume" form field
+router.post('/upload', upload.single('resume'), resumesController.uploadResume);
+router.get('/', resumesController.getResumes);
+router.post('/:id/feedback', resumesController.generateFeedback);
+router.get('/:id/feedback', resumesController.getFeedback);
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -30,6 +30,7 @@ app.use('/api/calendar', require('./routes/calendar.routes'));
 app.use('/api/friends', require('./routes/friends.routes'));
 app.use('/api/users', require('./routes/users.routes'));
 app.use('/api/comments', require('./routes/comments.routes'));
+app.use('/api/resumes', require('./routes/resumes.routes'));
 
 // Health check endpoint
 app.get('/health', (req, res) => {

--- a/backend/services/groq.service.js
+++ b/backend/services/groq.service.js
@@ -133,4 +133,73 @@ ${content}`;
     };
 };
 
-module.exports = { generateSummary, generateFlashcards };
+// ----------------------------------------
+// generateResumeFeedback
+// Purpose: Analyze a resume and return structured AI feedback
+// Returns: { overallScore, strengths, improvements, sections, keywordOptimization, model, tokenCount }
+//
+// overallScore        — 0-100 numeric rating
+// strengths           — array of things the resume does well
+// improvements        — array of actionable suggestions
+// sections            — per-section scores and feedback (Experience, Skills, Education, etc.)
+// keywordOptimization — { presentKeywords, missingKeywords }
+// ----------------------------------------
+const generateResumeFeedback = async (resumeText) => {
+    const systemPrompt = `You are an expert resume reviewer and career coach helping job seekers improve their resumes.
+Provide honest, specific, and actionable feedback. Score objectively based on clarity, impact, relevance, and ATS compatibility.
+Never make up information — only analyze what is present in the resume.`;
+
+    const userPrompt = `Review the following resume and return your response as a valid JSON object with exactly this structure:
+
+{
+  "overallScore": <integer 0-100>,
+  "strengths": ["<strength 1>", "<strength 2>", ...],
+  "improvements": ["<improvement 1>", "<improvement 2>", ...],
+  "sections": [
+    { "name": "<section name>", "feedback": "<specific feedback>", "score": <integer 0-100> },
+    ...
+  ],
+  "keywordOptimization": {
+    "presentKeywords": ["<keyword>", ...],
+    "missingKeywords": ["<keyword>", ...]
+  }
+}
+
+Rules:
+- overallScore: holistic rating (clarity, impact, relevance, ATS-friendliness)
+- strengths: 3-5 specific things the resume does well
+- improvements: 3-5 actionable, prioritized suggestions
+- sections: score and feedback for each section present (Experience, Education, Skills, Summary, etc.)
+- keywordOptimization: industry-relevant keywords found vs. commonly expected ones that are missing
+- Only return the JSON object. No extra text, no markdown code blocks.
+
+Resume:
+${resumeText}`;
+
+    const response = await groq.chat.completions.create({
+        model: MODEL,
+        messages: [
+            { role: 'system', content: systemPrompt },
+            { role: 'user', content: userPrompt },
+        ],
+        temperature: 0.3,
+        max_tokens: 2000,
+        response_format: { type: 'json_object' },
+    });
+
+    const raw = response.choices[0].message.content.trim();
+    const tokenCount = response.usage?.total_tokens ?? null;
+    const parsed = JSON.parse(raw);
+
+    return {
+        overallScore: parsed.overallScore,
+        strengths: parsed.strengths,
+        improvements: parsed.improvements,
+        sections: parsed.sections,
+        keywordOptimization: parsed.keywordOptimization,
+        model: MODEL,
+        tokenCount,
+    };
+};
+
+module.exports = { generateSummary, generateFlashcards, generateResumeFeedback };

--- a/docs/master_planning_doc.md
+++ b/docs/master_planning_doc.md
@@ -376,7 +376,7 @@ API-15. [x] `feat: add comment and like endpoints`
    - POST /api/comments/:id/like — toggle like
    - DELETE /api/comments/:id — soft delete comment
 
-API-16. [ ] `feat: add resume upload and ai feedback endpoints`
+API-16. [x] `feat: add resume upload and ai feedback endpoints`
    - POST /api/resumes/upload — upload resume PDF (with file validation)
    - GET /api/resumes — list user's resumes
    - POST /api/resumes/:id/feedback — generate AI feedback via Groq


### PR DESCRIPTION
## Summary
- Add `POST /api/resumes/upload` — upload resume PDF (10 MB limit); extracts text with `pdf-parse`, uploads to Cloudinary, caches `extractedText` for instant AI calls
- Add `GET /api/resumes` — list user's resumes (excludes `extractedText`)
- Add `POST /api/resumes/:id/feedback` — generate AI feedback via Groq; pushes new entry onto embedded `feedback[]` array
- Add `GET /api/resumes/:id/feedback` — return full feedback history
- Add `generateResumeFeedback` to `groq.service.js` — returns `overallScore`, `strengths`, `improvements`, `sections`, `keywordOptimization`
- Add `upload.middleware.js` — multer config (PDF only, 10 MB limit, memory storage)

Closes #27