### PR TITLE
API-19: test: test all session 5 endpoints with postman

### DIFF
--- a/backend/controllers/resumes.controller.js
+++ b/backend/controllers/resumes.controller.js
@@ -1,4 +1,4 @@
-const pdfParse = require('pdf-parse');
+const { PDFParse } = require('pdf-parse');
 const Resume = require('../models/Resume');
 const cloudinary = require('../config/cloudinary');
 const groqService = require('../services/groq.service');
@@ -49,7 +49,9 @@ exports.uploadResume = async (req, res) => {
     const { version, targetRole } = req.body;
 
     // Extract plain text from PDF buffer — cached so AI feedback is instant later
-    const pdfData = await pdfParse(req.file.buffer);
+    const parser = new PDFParse({ data: req.file.buffer });
+    const pdfData = await parser.getText();
+    await parser.destroy();
     const extractedText = pdfData.text;
 
     if (!extractedText || extractedText.trim().length === 0) {

--- a/backend/models/Resume.js
+++ b/backend/models/Resume.js
@@ -78,7 +78,10 @@ const resumeSchema = new mongoose.Schema({
             name: {
                 type: String,
             },
-            feedback: {
+            strength: {
+                type: String,
+            },
+            improvement: {
                 type: String,
             },
             score: {

--- a/backend/routes/resumes.routes.js
+++ b/backend/routes/resumes.routes.js
@@ -15,7 +15,15 @@ const upload = require('../middleware/upload.middleware');
 router.use(authMiddleware);
 
 // upload.single('resume') — expects a single file in the "resume" form field
-router.post('/upload', upload.single('resume'), resumesController.uploadResume);
+// Inline error handler catches multer fileFilter/size errors and returns JSON instead of HTML
+router.post('/upload', (req, res, next) => {
+    upload.single('resume')(req, res, (err) => {
+        if (err) {
+            return res.status(400).json({ success: false, error: err.message });
+        }
+        next();
+    });
+}, resumesController.uploadResume);
 router.get('/', resumesController.getResumes);
 router.post('/:id/feedback', resumesController.generateFeedback);
 router.get('/:id/feedback', resumesController.getFeedback);

--- a/backend/services/groq.service.js
+++ b/backend/services/groq.service.js
@@ -4,7 +4,9 @@ const groq = require('../config/groq');
 // GROQ SERVICE
 // Purpose: Centralized module for all Groq AI calls
 // Model: llama-3.1-8b-instant (14.4K RPD / 500K TPD on free tier)
-// Used by: notes.controller (summary), notes.controller (flashcards — API-8)
+// Used by: notes.controller (summary), notes.controller (flashcards — API-8), resumes.controller
+// Note: llama-3.3-70b-versatile has better reasoning but only 1K RPD on free tier —
+//       not viable for a multi-user product. Prompt engineering used instead for quality.
 // ============================================================
 
 const MODEL = 'llama-3.1-8b-instant';
@@ -145,18 +147,30 @@ ${content}`;
 // keywordOptimization — { presentKeywords, missingKeywords }
 // ----------------------------------------
 const generateResumeFeedback = async (resumeText) => {
-    const systemPrompt = `You are an expert resume reviewer and career coach helping job seekers improve their resumes.
-Provide honest, specific, and actionable feedback. Score objectively based on clarity, impact, relevance, and ATS compatibility.
-Never make up information — only analyze what is present in the resume.`;
+    const systemPrompt = `You are a senior technical recruiter and career coach who has reviewed thousands of resumes for top tech companies.
+You give brutally honest, deeply specific feedback that directly quotes and references what is written in the resume.
+You never give generic advice. Every sentence you write is grounded in the actual content of the resume being reviewed.
+Your feedback is the difference between a candidate getting an interview or being passed over.`;
 
-    const userPrompt = `Review the following resume and return your response as a valid JSON object with exactly this structure:
+    const userPrompt = `Review the following resume thoroughly and return a valid JSON object with exactly this structure:
 
 {
   "overallScore": <integer 0-100>,
-  "strengths": ["<strength 1>", "<strength 2>", ...],
-  "improvements": ["<improvement 1>", "<improvement 2>", ...],
+  "strengths": [
+    "<Strength item — follow this pattern: Start with what specifically stands out and why it matters to a recruiter. Quote or directly reference the specific bullet, project, metric, or section. Then explain the impact this has on a hiring decision. Each item must be 3-5 sentences.>",
+    ...
+  ],
+  "improvements": [
+    "<Improvement item — follow this pattern: Start with 'Problem:' and describe exactly what is weak, missing, or unclear, quoting the specific line or section. Then write 'Fix:' and give a concrete, ready-to-use rewrite or specific instruction. Each item must be 3-5 sentences total.>",
+    ...
+  ],
   "sections": [
-    { "name": "<section name>", "feedback": "<specific feedback>", "score": <integer 0-100> },
+    {
+      "name": "<section name>",
+      "strength": "<2-3 sentences: what this section does well, quoting specific content from it>",
+      "improvement": "<2-3 sentences: the single most important thing to fix in this section — state the problem and give the exact fix>",
+      "score": <integer 0-100>
+    },
     ...
   ],
   "keywordOptimization": {
@@ -165,12 +179,13 @@ Never make up information — only analyze what is present in the resume.`;
   }
 }
 
-Rules:
-- overallScore: holistic rating (clarity, impact, relevance, ATS-friendliness)
-- strengths: 3-5 specific things the resume does well
-- improvements: 3-5 actionable, prioritized suggestions
-- sections: score and feedback for each section present (Experience, Education, Skills, Summary, etc.)
-- keywordOptimization: industry-relevant keywords found vs. commonly expected ones that are missing
+Strict rules:
+- overallScore: holistic score based on clarity, impact, quantification, ATS-friendliness, and recruiter appeal
+- strengths: exactly 5 items — each 3-5 sentences — must quote or directly reference specific resume content — no vague praise
+- improvements: exactly 5 items — each must have a clear "Problem:" sentence and a "Fix:" sentence — must reference specific lines
+- sections: one entry per section present in the resume — strength and improvement each 2-3 sentences
+- missingKeywords: keywords a recruiter for this candidate's field would expect to see but are absent
+- Every single item must be specific enough that the candidate knows exactly what to change and how
 - Only return the JSON object. No extra text, no markdown code blocks.
 
 Resume:
@@ -183,7 +198,7 @@ ${resumeText}`;
             { role: 'user', content: userPrompt },
         ],
         temperature: 0.3,
-        max_tokens: 2000,
+        max_tokens: 3500,
         response_format: { type: 'json_object' },
     });
 

--- a/backend/testing/postman/README.md
+++ b/backend/testing/postman/README.md
@@ -139,3 +139,143 @@ Run top to bottom within each folder. Each creation request auto-sets the ID for
 - If a request fails with `401 Unauthorized`, your token may have expired — re-run **Login** to refresh it
 - If a request fails with `404 Not Found`, the ID variable may be stale — re-run the creation request for that resource
 - The Groq summary and flashcard generation requests take 2-5 seconds — this is normal
+
+---
+
+# Postman Testing — Session 5
+
+API-13 through API-18: Friends, Note Sharing, Comments/Likes, Resume Upload, Applications, Shared Tasks.
+
+---
+
+## Setup
+
+### 1. Import the collection
+- Open Postman → **Collections** tab → **Import** → select `continuum-session5.postman_collection.json`
+- The environment (`continuum-local.postman_environment.json`) is shared with session 3-4 — re-import it to pick up the new variables added for session 5, or just re-use the existing one (new variables will be auto-set by test scripts)
+
+### 2. Select the environment
+- Top-right corner of Postman — switch the dropdown to **Continuum — Local**
+
+### 3. Start the backend server
+```bash
+cd backend && npm run dev
+```
+
+---
+
+## Environment Variables
+
+New variables added for session 5. All are auto-set by test scripts.
+
+| Variable          | Set by                  | Used by                                      |
+|-------------------|-------------------------|----------------------------------------------|
+| `secondToken`     | Register User 2         | All "as User 2" requests                     |
+| `secondUserId`    | Register User 2         | Send Friend Request, Share Note (specific), Create Shared Task |
+| `friendshipId`    | Send Friend Request     | Accept/Remove Friend routes                  |
+| `noteId`          | Create Note (for Sharing) | Share, Comment, Get Shared routes           |
+| `commentId`       | Add Comment             | Like, Delete Comment routes                  |
+| `resumeId`        | Upload Resume           | Feedback routes                              |
+| `applicationId`   | Create Application      | Update, Contacts, Reminders routes           |
+| `sharedTaskId`    | Create Shared Task      | Participant Status, Calendar routes          |
+| `calFrom` / `calTo` | Pre-request script    | Get Calendar (Shared Tasks folder)           |
+
+---
+
+## Test Order
+
+Run folders top to bottom. **Do not run "Remove Friend" until after all Note Sharing and Shared Tasks tests** — it will break the specific sharing and shared task flows.
+
+### 0. Setup — Second User
+*(Run these first, in order)*
+
+| Request | Body Input | Expected | Tested |
+|---------|------------|----------|--------|
+| Login User 1 | `{ "email", "password" }` | `200` — sets `token` + `userId` | ✅ |
+| Register User 2 | `{ "username", "email", "password", "firstName", "lastName" }` | `201` — sets `secondToken` + `secondUserId` | ✅ |
+
+### 1. Users
+| Request | Body Input | Expected | Tested |
+|---------|------------|----------|--------|
+| Search Users | query: `?q=testuser2` | `200` — returns array of matching users | ✅ |
+| [Error] Search — Missing Query | none | `400` | ✅ |
+
+### 2. Friends
+| Request | Body Input | Expected | Tested |
+|---------|------------|----------|--------|
+| Send Friend Request | `{ "recipientId": "{{secondUserId}}" }` | `201` — sets `friendshipId` | ✅ |
+| Accept Request — as User 2 | `{ "action": "accept" }` | `200` | ✅ |
+| List Friends | none | `200` — includes User 2 with `status: accepted` | ✅ |
+| List Pending Requests | query: `?status=pending` | `200` — empty after acceptance | ✅ |
+| [Error] Send to Self | `{ "recipientId": "{{userId}}" }` | `400` | ✅ |
+| [Error] Duplicate Request | `{ "recipientId": "{{secondUserId}}" }` | `400` | ✅ |
+| Remove Friend ⚠️ | none | `200` — **run AFTER Note Sharing and Shared Tasks** | ✅ |
+
+### 3. Note Sharing
+*(Requires friendship to be accepted — run 2. Friends first)*
+
+| Request | Body Input | Expected | Tested |
+|---------|------------|----------|--------|
+| Create Note (for Sharing) | `{ "title", "content", "tags" }` | `201` — sets `noteId` | ✅ |
+| Share Note — Friends | `{ "visibility": "friends" }` | `200` | ✅ |
+| Share Note — Specific Users | `{ "visibility": "specific", "sharedWith": ["{{secondUserId}}"] }` | `200` | ✅ |
+| Get Shared Notes — as User 2 | none | `200` — note appears in results | ✅ |
+| Get Shared Notes — as User 1 | none | `200` — empty (User 1 has no notes shared with them) | ✅ |
+| [Error] Share with Non-Friend | `{ "visibility": "specific", "sharedWith": ["000000000000000000000000"] }` | `400` | ✅ |
+
+### 4. Comments & Likes
+| Request | Body Input | Expected | Tested |
+|---------|------------|----------|--------|
+| Add Comment | `{ "targetType": "note", "targetId": "{{noteId}}", "content": "..." }` | `201` — sets `commentId` | ✅ |
+| Get Comments | none | `200` — includes the new comment with `userSnapshot` | ✅ |
+| Toggle Like — On | none | `200` — check `liked: true` | ✅ |
+| Toggle Like — Off | none | `200` — check `liked: false` | ✅ |
+| Delete Comment | none | `200` | ✅ |
+| [Error] Add Comment — Missing Content | `{ "targetType", "targetId" }` only | `400` | ✅ |
+| [Error] Add Comment — Invalid targetType | `{ "targetType": "invalid", ... }` | `400` | ✅ |
+
+### 5. Resumes
+*(Requires a real PDF file — select it manually in the Upload Resume request)*
+
+| Request | Body Input | Expected | Tested |
+|---------|------------|----------|--------|
+| Upload Resume | form-data: `resume` = any PDF file | `201` — sets `resumeId` | ✅ |
+| List Resumes | none | `200` | ✅ |
+| Generate AI Feedback | none | `200` — takes 2-5s (Groq API call) — check `overallScore`, `strengths`, `improvements` | ✅ |
+| Get Feedback History | none | `200` — `feedback` array with the generated entry | ✅ |
+| [Error] Upload Non-PDF | form-data: `resume` = any non-PDF file | `400` | ✅ |
+
+### 6. Applications
+| Request | Body Input | Expected | Tested |
+|---------|------------|----------|--------|
+| Create Application | `{ "company", "position", "location", "status", "appliedAt", "notes" }` | `201` — sets `applicationId` | ✅ |
+| List Applications | none | `200` | ✅ |
+| List Applications — Status Filter | query: `?status=applied` | `200` | ✅ |
+| List Applications — Search Filter | query: `?search=Google` | `200` | ✅ |
+| Update Application | `{ "status": "interview", "notes": "..." }` | `200` — check `status` updated | ✅ |
+| Get Dashboard | none | `200` — check `pipeline` object with counts per status | ✅ |
+| Add Contact | `{ "name", "role", "email", "linkedIn", "notes" }` | `201` — contact appears in `application.contacts` | ✅ |
+| Add Reminder | `{ "date", "description" }` | `201` — reminder appears in `application.followUpReminders` | ✅ |
+| [Error] Create — Missing company | `{ "position": "..." }` only | `400` | ✅ |
+| [Error] Create — Missing position | `{ "company": "..." }` only | `400` | ✅ |
+
+### 7. Shared Tasks
+*(Requires friendship to be accepted — run 2. Friends first)*
+
+| Request | Body Input | Expected | Tested |
+|---------|------------|----------|--------|
+| Create Shared Task | `{ "title", "dueDate", "isShared": true, "participants": [{ "userId": "{{secondUserId}}" }] }` | `201` — sets `sharedTaskId`, `participants` array populated | ✅ |
+| Get Shared Tasks — as User 2 | none | `200` — shared task appears | ✅ |
+| Update Participant Status — as User 2 | `{ "status": "in_progress" }` | `200` — User 2's participant entry updated | ✅ |
+| Get Calendar — verify shared task (User 2) | query: `?from=2026-03-01&to=2026-03-31&view=month` | `200` — shared task appears in `days` | ✅ |
+| [Error] Participant Status — Invalid Value | `{ "status": "done" }` | `400` | ✅ |
+| [Error] Non-Participant Update | `{ "status": "completed" }` (as User 1, on shared task) | `404` — User 1 is the owner, not a participant | ✅ |
+
+---
+
+## Tips
+
+- Run folder **0. Setup** first every time — it ensures `token`, `userId`, `secondToken`, `secondUserId` are all set
+- **Remove Friend** (bottom of folder 2) must be run **after** folders 3 and 7 — specific note sharing and shared tasks require an active friendship
+- Resume upload requires a real PDF file — select it manually via the file chooser in Postman
+- The AI Feedback request (Resumes) takes 2-5 seconds — this is normal (Groq API call)

--- a/backend/testing/postman/continuum-local.postman_environment.json
+++ b/backend/testing/postman/continuum-local.postman_environment.json
@@ -2,14 +2,23 @@
   "id": "env-continuum-local",
   "name": "Continuum — Local",
   "values": [
-    { "key": "baseUrl",        "value": "http://localhost:5001", "type": "default", "enabled": true },
-    { "key": "token",          "value": "",                      "type": "secret",  "enabled": true },
-    { "key": "googleToken",    "value": "",                      "type": "secret",  "enabled": true },
-    { "key": "userId",         "value": "",                      "type": "default", "enabled": true },
-    { "key": "noteId",         "value": "",                      "type": "default", "enabled": true },
-    { "key": "flashcardSetId", "value": "",                      "type": "default", "enabled": true },
-    { "key": "flashcardId",    "value": "",                      "type": "default", "enabled": true },
-    { "key": "taskId",         "value": "",                      "type": "default", "enabled": true }
+    { "key": "baseUrl",         "value": "http://localhost:5001", "type": "default", "enabled": true },
+    { "key": "token",           "value": "",                      "type": "secret",  "enabled": true },
+    { "key": "googleToken",     "value": "",                      "type": "secret",  "enabled": true },
+    { "key": "userId",          "value": "",                      "type": "default", "enabled": true },
+    { "key": "noteId",          "value": "",                      "type": "default", "enabled": true },
+    { "key": "flashcardSetId",  "value": "",                      "type": "default", "enabled": true },
+    { "key": "flashcardId",     "value": "",                      "type": "default", "enabled": true },
+    { "key": "taskId",          "value": "",                      "type": "default", "enabled": true },
+    { "key": "secondToken",     "value": "",                      "type": "secret",  "enabled": true },
+    { "key": "secondUserId",    "value": "",                      "type": "default", "enabled": true },
+    { "key": "friendshipId",    "value": "",                      "type": "default", "enabled": true },
+    { "key": "commentId",       "value": "",                      "type": "default", "enabled": true },
+    { "key": "resumeId",        "value": "",                      "type": "default", "enabled": true },
+    { "key": "applicationId",   "value": "",                      "type": "default", "enabled": true },
+    { "key": "sharedTaskId",    "value": "",                      "type": "default", "enabled": true },
+    { "key": "calFrom",         "value": "",                      "type": "default", "enabled": true },
+    { "key": "calTo",           "value": "",                      "type": "default", "enabled": true }
   ],
   "_postman_variable_scope": "environment"
 }

--- a/backend/testing/postman/continuum-session5.postman_collection.json
+++ b/backend/testing/postman/continuum-session5.postman_collection.json
@@ -1,0 +1,929 @@
+{
+  "info": {
+    "_postman_id": "c3d4e5f6-a7b8-9012-cdef-012345678902",
+    "name": "Continuum — Session 5",
+    "description": "API-13 through API-18: Friends, Note Sharing, Comments/Likes, Resume Upload, Applications, Shared Tasks.\n\nRun order: 0. Setup → 1. Users → 2. Friends → 3. Note Sharing → 4. Comments → 5. Resumes → 6. Applications → 7. Shared Tasks.\nToken + IDs are auto-set by test scripts — run Login User 1 first.",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "auth": {
+    "type": "bearer",
+    "bearer": [
+      { "key": "token", "value": "{{token}}", "type": "string" }
+    ]
+  },
+  "item": [
+    {
+      "name": "0. Setup — Second User",
+      "item": [
+        {
+          "name": "Login User 1",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if (pm.response.code === 200) {",
+                  "    const json = pm.response.json();",
+                  "    pm.environment.set('token', json.token);",
+                  "    pm.environment.set('userId', json.user._id);",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "auth": { "type": "noauth" },
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"email\": \"test@example.com\",\n  \"password\": \"Password123!\"\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/auth/login",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "auth", "login"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Register User 2",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if (pm.response.code === 201) {",
+                  "    const json = pm.response.json();",
+                  "    pm.environment.set('secondToken', json.token);",
+                  "    pm.environment.set('secondUserId', json.user._id);",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "auth": { "type": "noauth" },
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"username\": \"testuser2\",\n  \"email\": \"test2@example.com\",\n  \"password\": \"Password123!\",\n  \"firstName\": \"Test\",\n  \"lastName\": \"Two\"\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/auth/register",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "auth", "register"]
+            }
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "1. Users",
+      "item": [
+        {
+          "name": "Search Users",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/api/users/search?q=testuser2",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "users", "search"],
+              "query": [{ "key": "q", "value": "testuser2" }]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "[Error] Search — Missing Query",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/api/users/search",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "users", "search"]
+            }
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "2. Friends",
+      "item": [
+        {
+          "name": "Send Friend Request",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if (pm.response.code === 201) {",
+                  "    const json = pm.response.json();",
+                  "    pm.environment.set('friendshipId', json.friendship._id);",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"recipientId\": \"{{secondUserId}}\"\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/friends/request",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "friends", "request"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Accept Request — as User 2",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [{ "key": "token", "value": "{{secondToken}}", "type": "string" }]
+            },
+            "method": "PUT",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"action\": \"accept\"\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/friends/request/{{friendshipId}}",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "friends", "request", "{{friendshipId}}"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "List Friends",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/api/friends",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "friends"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "List Pending Requests",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/api/friends?status=pending",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "friends"],
+              "query": [{ "key": "status", "value": "pending" }]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "[Error] Send to Self",
+          "request": {
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"recipientId\": \"{{userId}}\"\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/friends/request",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "friends", "request"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "[Error] Duplicate Request",
+          "request": {
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"recipientId\": \"{{secondUserId}}\"\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/friends/request",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "friends", "request"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Remove Friend ⚠️ Run After All Other Folders",
+          "request": {
+            "method": "DELETE",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/api/friends/{{friendshipId}}",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "friends", "{{friendshipId}}"]
+            }
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "3. Note Sharing",
+      "item": [
+        {
+          "name": "Create Note (for Sharing)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if (pm.response.code === 201) {",
+                  "    const json = pm.response.json();",
+                  "    pm.environment.set('noteId', json.note._id);",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"title\": \"Shared Study Notes\",\n  \"content\": \"These are notes about machine learning, neural networks, and deep learning concepts. Gradient descent optimizes model weights. Backpropagation computes gradients through layers. Loss functions measure prediction error.\",\n  \"tags\": [\"ml\", \"ai\"]\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/notes",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "notes"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Share Note — Friends",
+          "request": {
+            "method": "PUT",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"visibility\": \"friends\"\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/notes/{{noteId}}/share",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "notes", "{{noteId}}", "share"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Share Note — Specific Users",
+          "request": {
+            "method": "PUT",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"visibility\": \"specific\",\n  \"sharedWith\": [\"{{secondUserId}}\"]\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/notes/{{noteId}}/share",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "notes", "{{noteId}}", "share"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Get Shared Notes — as User 2",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [{ "key": "token", "value": "{{secondToken}}", "type": "string" }]
+            },
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/api/notes/shared",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "notes", "shared"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Get Shared Notes — as User 1",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/api/notes/shared",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "notes", "shared"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "[Error] Share with Non-Friend",
+          "request": {
+            "method": "PUT",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"visibility\": \"specific\",\n  \"sharedWith\": [\"000000000000000000000000\"]\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/notes/{{noteId}}/share",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "notes", "{{noteId}}", "share"]
+            }
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "4. Comments & Likes",
+      "item": [
+        {
+          "name": "Add Comment",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if (pm.response.code === 201) {",
+                  "    const json = pm.response.json();",
+                  "    pm.environment.set('commentId', json.comment._id);",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"targetType\": \"note\",\n  \"targetId\": \"{{noteId}}\",\n  \"content\": \"Great notes! Really helpful for the exam.\"\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/comments",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "comments"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Get Comments",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/api/comments/note/{{noteId}}",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "comments", "note", "{{noteId}}"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Toggle Like — On",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/api/comments/{{commentId}}/like",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "comments", "{{commentId}}", "like"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Toggle Like — Off",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/api/comments/{{commentId}}/like",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "comments", "{{commentId}}", "like"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Delete Comment",
+          "request": {
+            "method": "DELETE",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/api/comments/{{commentId}}",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "comments", "{{commentId}}"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "[Error] Add Comment — Missing Content",
+          "request": {
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"targetType\": \"note\",\n  \"targetId\": \"{{noteId}}\"\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/comments",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "comments"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "[Error] Add Comment — Invalid targetType",
+          "request": {
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"targetType\": \"invalid\",\n  \"targetId\": \"{{noteId}}\",\n  \"content\": \"This should fail\"\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/comments",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "comments"]
+            }
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "5. Resumes",
+      "item": [
+        {
+          "name": "Upload Resume",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if (pm.response.code === 201) {",
+                  "    const json = pm.response.json();",
+                  "    pm.environment.set('resumeId', json.resume._id);",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "formdata",
+              "formdata": [
+                { "key": "resume", "type": "file", "src": [], "description": "Select a PDF resume file" }
+              ]
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/resumes/upload",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "resumes", "upload"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "List Resumes",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/api/resumes",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "resumes"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Generate AI Feedback",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/api/resumes/{{resumeId}}/feedback",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "resumes", "{{resumeId}}", "feedback"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Get Feedback History",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/api/resumes/{{resumeId}}/feedback",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "resumes", "{{resumeId}}", "feedback"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "[Error] Upload Non-PDF",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "formdata",
+              "formdata": [
+                { "key": "resume", "type": "file", "src": [], "description": "Select any non-PDF file (e.g. .txt or .png)" }
+              ]
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/resumes/upload",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "resumes", "upload"]
+            }
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "6. Applications",
+      "item": [
+        {
+          "name": "Create Application",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if (pm.response.code === 201) {",
+                  "    const json = pm.response.json();",
+                  "    pm.environment.set('applicationId', json.application._id);",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"company\": \"Google\",\n  \"position\": \"Software Engineer Intern\",\n  \"location\": \"Mountain View, CA\",\n  \"jobUrl\": \"https://careers.google.com/jobs/\",\n  \"status\": \"applied\",\n  \"appliedAt\": \"2026-03-01T00:00:00.000Z\",\n  \"notes\": \"Applied through the Google careers portal.\"\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/applications",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "applications"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "List Applications",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/api/applications",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "applications"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "List Applications — Status Filter",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/api/applications?status=applied",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "applications"],
+              "query": [{ "key": "status", "value": "applied" }]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "List Applications — Search Filter",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/api/applications?search=Google",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "applications"],
+              "query": [{ "key": "search", "value": "Google" }]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Update Application",
+          "request": {
+            "method": "PUT",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"status\": \"interview\",\n  \"notes\": \"Phone screen scheduled for next week.\"\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/applications/{{applicationId}}",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "applications", "{{applicationId}}"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Get Dashboard",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/api/applications/dashboard",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "applications", "dashboard"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Add Contact",
+          "request": {
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"name\": \"Jane Recruiter\",\n  \"role\": \"University Recruiter\",\n  \"email\": \"jane@google.com\",\n  \"linkedIn\": \"https://linkedin.com/in/janerecruiter\",\n  \"notes\": \"Met at career fair\"\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/applications/{{applicationId}}/contacts",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "applications", "{{applicationId}}", "contacts"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Add Reminder",
+          "request": {
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"date\": \"2026-03-10T09:00:00.000Z\",\n  \"description\": \"Follow up if no response by end of week\"\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/applications/{{applicationId}}/reminders",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "applications", "{{applicationId}}", "reminders"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "[Error] Create — Missing company",
+          "request": {
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"position\": \"Software Engineer\"\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/applications",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "applications"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "[Error] Create — Missing position",
+          "request": {
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"company\": \"Meta\"\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/applications",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "applications"]
+            }
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "7. Shared Tasks",
+      "item": [
+        {
+          "name": "Create Shared Task",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if (pm.response.code === 201) {",
+                  "    const json = pm.response.json();",
+                  "    pm.environment.set('sharedTaskId', json.task._id);",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"title\": \"Group Project Milestone\",\n  \"dueDate\": \"2026-03-15T23:59:00.000Z\",\n  \"type\": \"project\",\n  \"priority\": \"high\",\n  \"description\": \"Complete the first draft of the group project report\",\n  \"isShared\": true,\n  \"participants\": [{ \"userId\": \"{{secondUserId}}\" }]\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/tasks",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "tasks"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Get Shared Tasks — as User 2",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [{ "key": "token", "value": "{{secondToken}}", "type": "string" }]
+            },
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/api/tasks/shared",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "tasks", "shared"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Update Participant Status — as User 2",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [{ "key": "token", "value": "{{secondToken}}", "type": "string" }]
+            },
+            "method": "PATCH",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"status\": \"in_progress\"\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/tasks/{{sharedTaskId}}/participant-status",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "tasks", "{{sharedTaskId}}", "participant-status"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Get Calendar — verify shared task (User 2)",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.environment.set('calFrom', '2026-03-01');",
+                  "pm.environment.set('calTo', '2026-03-31');"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [{ "key": "token", "value": "{{secondToken}}", "type": "string" }]
+            },
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/api/calendar?from={{calFrom}}&to={{calTo}}&view=month",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "calendar"],
+              "query": [
+                { "key": "from", "value": "{{calFrom}}" },
+                { "key": "to", "value": "{{calTo}}" },
+                { "key": "view", "value": "month" }
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "[Error] Participant Status — Invalid Value",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [{ "key": "token", "value": "{{secondToken}}", "type": "string" }]
+            },
+            "method": "PATCH",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"status\": \"done\"\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/tasks/{{sharedTaskId}}/participant-status",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "tasks", "{{sharedTaskId}}", "participant-status"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "[Error] Non-Participant Update",
+          "request": {
+            "method": "PATCH",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"status\": \"completed\"\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/tasks/{{sharedTaskId}}/participant-status",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "tasks", "{{sharedTaskId}}", "participant-status"]
+            }
+          },
+          "response": []
+        }
+      ]
+    }
+  ]
+}

--- a/docs/master_planning_doc.md
+++ b/docs/master_planning_doc.md
@@ -395,7 +395,7 @@ API-18. [x] `feat: implement shared tasks with participants`
    - GET /api/tasks/shared — list tasks shared with user
    - Shared tasks appear in all participants' calendars
 
-API-19. [ ] `test: test all session 5 endpoints with postman`
+API-19. [x] `test: test all session 5 endpoints with postman`
    - Test friend request flow end-to-end
    - Test sharing and visibility
    - Test file upload


### PR DESCRIPTION
## Summary
- Ran full Postman test suite for session 5 endpoints (API-13 through API-18)
- Fixed pdf-parse v2 breaking change in resumes controller (`PDFParse` class instead of function)
- Fixed multer fileFilter errors returning HTML — added inline error handler in resumes route
- Improved `generateResumeFeedback` prompt for deeper, more actionable AI feedback with `Problem:/Fix:` structure
- Updated Resume model sections schema to include separate `strength` and `improvement` fields

Closes #30