### PR TITLE
API-20: feat: add stretch api endpoints (messaging)

### DIFF
--- a/backend/controllers/conversations.controller.js
+++ b/backend/controllers/conversations.controller.js
@@ -1,0 +1,185 @@
+const Conversation = require('../models/Conversation');
+const Message = require('../models/Message');
+
+// ============================================================
+// CONVERSATIONS CONTROLLER
+// Purpose: Handle all messaging endpoints — conversations and messages
+// Routes:
+//   POST   /api/conversations             — start or get existing conversation
+//   GET    /api/conversations             — list user's inbox
+//   POST   /api/conversations/:id/messages — send a message
+//   GET    /api/conversations/:id/messages — get messages (paginated)
+// ============================================================
+
+// ----------------------------------------
+// startConversation
+// Purpose: Find or create a 1-on-1 conversation with another user
+// Idempotent: returns existing conversation if one already exists
+// ----------------------------------------
+exports.startConversation = async (req, res) => {
+    const { participantId } = req.body;
+    const userId = req.user._id;
+
+    if (!participantId) {
+        return res.status(400).json({ success: false, error: 'participantId is required' });
+    }
+
+    if (participantId === userId.toString()) {
+        return res.status(400).json({ success: false, error: 'You cannot start a conversation with yourself' });
+    }
+
+    // Sort IDs to create a canonical pair — prevents [A,B] vs [B,A] duplicates
+    const participants = [userId, participantId].sort();
+
+    // Check if conversation already exists
+    const existing = await Conversation.findOne({
+        participants: { $all: participants },
+        deletedAt: null,
+    }).populate('participants', 'username firstName lastName');
+
+    if (existing) {
+        return res.status(200).json({ success: true, conversation: existing });
+    }
+
+    // Create new conversation with unread counts initialized to 0 for both participants
+    const conversation = await Conversation.create({
+        participants,
+        unreadCounts: [
+            { userId, count: 0 },
+            { userId: participantId, count: 0 },
+        ],
+    });
+
+    await conversation.populate('participants', 'username firstName lastName');
+
+    res.status(201).json({ success: true, conversation });
+};
+
+// ----------------------------------------
+// getConversations
+// Purpose: List the current user's inbox, sorted by most recent message
+// ----------------------------------------
+exports.getConversations = async (req, res) => {
+    const userId = req.user._id;
+
+    const conversations = await Conversation.find({
+        participants: userId,
+        deletedAt: null,
+    })
+        .populate('participants', 'username firstName lastName')
+        .sort({ 'lastMessage.sentAt': -1, createdAt: -1 });
+
+    res.status(200).json({ success: true, conversations });
+};
+
+// ----------------------------------------
+// sendMessage
+// Purpose: Send a message in a conversation
+// Side effects:
+//   - Updates conversation.lastMessage (denormalized inbox preview)
+//   - Increments unread count for the other participant
+// ----------------------------------------
+exports.sendMessage = async (req, res) => {
+    const { id: conversationId } = req.params;
+    const { content } = req.body;
+    const userId = req.user._id;
+
+    if (!content || !content.trim()) {
+        return res.status(400).json({ success: false, error: 'content is required' });
+    }
+
+    const conversation = await Conversation.findOne({
+        _id: conversationId,
+        deletedAt: null,
+    });
+
+    if (!conversation) {
+        return res.status(404).json({ success: false, error: 'Conversation not found' });
+    }
+
+    const isParticipant = conversation.participants.some(
+        (p) => p.toString() === userId.toString()
+    );
+    if (!isParticipant) {
+        return res.status(403).json({ success: false, error: 'You are not a participant in this conversation' });
+    }
+
+    const message = await Message.create({
+        conversationId,
+        senderId: userId,
+        content: content.trim(),
+    });
+
+    // Update denormalized last message preview on the conversation
+    conversation.lastMessage = {
+        senderId: userId,
+        content: content.trim().substring(0, 200),
+        sentAt: message.createdAt,
+    };
+
+    // Increment unread count for the other participant
+    const otherParticipantId = conversation.participants.find(
+        (p) => p.toString() !== userId.toString()
+    );
+    if (otherParticipantId) {
+        const unreadEntry = conversation.unreadCounts.find(
+            (u) => u.userId.toString() === otherParticipantId.toString()
+        );
+        if (unreadEntry) {
+            unreadEntry.count += 1;
+        } else {
+            conversation.unreadCounts.push({ userId: otherParticipantId, count: 1 });
+        }
+    }
+
+    await conversation.save();
+
+    await message.populate('senderId', 'username firstName lastName');
+
+    res.status(201).json({ success: true, message });
+};
+
+// ----------------------------------------
+// getMessages
+// Purpose: Get paginated messages in a conversation (newest first)
+// Query params:
+//   limit  — number of messages to return (default 50, max 100)
+//   before — ISO date cursor, returns only messages created before this timestamp
+// ----------------------------------------
+exports.getMessages = async (req, res) => {
+    const { id: conversationId } = req.params;
+    const userId = req.user._id;
+
+    const limit = Math.min(parseInt(req.query.limit) || 50, 100);
+    const before = req.query.before ? new Date(req.query.before) : new Date();
+
+    const conversation = await Conversation.findOne({
+        _id: conversationId,
+        deletedAt: null,
+    });
+
+    if (!conversation) {
+        return res.status(404).json({ success: false, error: 'Conversation not found' });
+    }
+
+    const isParticipant = conversation.participants.some(
+        (p) => p.toString() === userId.toString()
+    );
+    if (!isParticipant) {
+        return res.status(403).json({ success: false, error: 'You are not a participant in this conversation' });
+    }
+
+    const messages = await Message.find({
+        conversationId,
+        deletedAt: null,
+        createdAt: { $lt: before },
+    })
+        .populate('senderId', 'username firstName lastName')
+        .sort({ createdAt: -1 })
+        .limit(limit + 1); // fetch one extra to determine hasMore
+
+    const hasMore = messages.length > limit;
+    if (hasMore) messages.pop();
+
+    res.status(200).json({ success: true, messages, hasMore });
+};

--- a/backend/controllers/messages.controller.js
+++ b/backend/controllers/messages.controller.js
@@ -1,0 +1,63 @@
+const Message = require('../models/Message');
+const Conversation = require('../models/Conversation');
+
+// ============================================================
+// MESSAGES CONTROLLER
+// Purpose: Handle message-level actions
+// Routes:
+//   PUT /api/messages/:id/read — mark a message as read
+// ============================================================
+
+// ----------------------------------------
+// markAsRead
+// Purpose: Mark a message as read by the current user
+// Side effects:
+//   - Adds userId + readAt to message.readBy (if not already present)
+//   - Resets the user's unreadCounts to 0 in the conversation
+// ----------------------------------------
+exports.markAsRead = async (req, res) => {
+    const { id: messageId } = req.params;
+    const userId = req.user._id;
+
+    const message = await Message.findOne({ _id: messageId, deletedAt: null });
+
+    if (!message) {
+        return res.status(404).json({ success: false, error: 'Message not found' });
+    }
+
+    const conversation = await Conversation.findOne({
+        _id: message.conversationId,
+        deletedAt: null,
+    });
+
+    if (!conversation) {
+        return res.status(404).json({ success: false, error: 'Conversation not found' });
+    }
+
+    const isParticipant = conversation.participants.some(
+        (p) => p.toString() === userId.toString()
+    );
+    if (!isParticipant) {
+        return res.status(403).json({ success: false, error: 'You are not a participant in this conversation' });
+    }
+
+    // Add to readBy only if not already present
+    const alreadyRead = message.readBy.some(
+        (r) => r.userId.toString() === userId.toString()
+    );
+    if (!alreadyRead) {
+        message.readBy.push({ userId, readAt: new Date() });
+        await message.save();
+    }
+
+    // Reset this user's unread count to 0 in the conversation
+    const unreadEntry = conversation.unreadCounts.find(
+        (u) => u.userId.toString() === userId.toString()
+    );
+    if (unreadEntry && unreadEntry.count > 0) {
+        unreadEntry.count = 0;
+        await conversation.save();
+    }
+
+    res.status(200).json({ success: true, message });
+};

--- a/backend/routes/conversations.routes.js
+++ b/backend/routes/conversations.routes.js
@@ -1,0 +1,20 @@
+const express = require('express');
+const router = express.Router();
+const conversationsController = require('../controllers/conversations.controller');
+const authMiddleware = require('../middleware/auth.middleware');
+
+// ============================================================
+// CONVERSATIONS ROUTES
+// Purpose: Map HTTP endpoints to conversations controller functions
+// Base path: /api/conversations (mounted in server.js)
+// All routes are protected — JWT required
+// ============================================================
+
+router.use(authMiddleware);
+
+router.post('/', conversationsController.startConversation);
+router.get('/', conversationsController.getConversations);
+router.post('/:id/messages', conversationsController.sendMessage);
+router.get('/:id/messages', conversationsController.getMessages);
+
+module.exports = router;

--- a/backend/routes/messages.routes.js
+++ b/backend/routes/messages.routes.js
@@ -1,0 +1,17 @@
+const express = require('express');
+const router = express.Router();
+const messagesController = require('../controllers/messages.controller');
+const authMiddleware = require('../middleware/auth.middleware');
+
+// ============================================================
+// MESSAGES ROUTES
+// Purpose: Map HTTP endpoints to messages controller functions
+// Base path: /api/messages (mounted in server.js)
+// All routes are protected — JWT required
+// ============================================================
+
+router.use(authMiddleware);
+
+router.put('/:id/read', messagesController.markAsRead);
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -32,6 +32,8 @@ app.use('/api/users', require('./routes/users.routes'));
 app.use('/api/comments', require('./routes/comments.routes'));
 app.use('/api/applications', require('./routes/applications.routes'));
 app.use('/api/resumes', require('./routes/resumes.routes'));
+app.use('/api/conversations', require('./routes/conversations.routes'));
+app.use('/api/messages', require('./routes/messages.routes'));
 
 // Health check endpoint
 app.get('/health', (req, res) => {

--- a/docs/master_planning_doc.md
+++ b/docs/master_planning_doc.md
@@ -401,7 +401,7 @@ API-19. [x] `test: test all session 5 endpoints with postman`
    - Test file upload
    - Verify all protected routes
 
-API-20. [ ] `feat: add stretch api endpoints (messaging)` *(stretch)*
+API-20. [x] `feat: add stretch api endpoints (messaging)` *(stretch)*
    - POST /api/conversations — start conversation
    - GET /api/conversations — list conversations (inbox)
    - POST /api/conversations/:id/messages — send message


### PR DESCRIPTION
## Summary
- Implement 1-on-1 DM messaging between users (API-20)
- `POST /api/conversations` — start or get existing conversation (idempotent, find-or-create)
- `GET /api/conversations` — list inbox sorted by most recent message
- `POST /api/conversations/:id/messages` — send a message, updates denormalized `lastMessage` and increments recipient unread count
- `GET /api/conversations/:id/messages` — paginated messages with `?limit` and `?before` cursor
- `PUT /api/messages/:id/read` — mark message as read, resets unread count for that participant

Closes #31