### PR TITLE
API-21: test: test stretch api endpoints with postman

### DIFF
--- a/backend/testing/postman/README.md
+++ b/backend/testing/postman/README.md
@@ -279,3 +279,85 @@ Run folders top to bottom. **Do not run "Remove Friend" until after all Note Sha
 - **Remove Friend** (bottom of folder 2) must be run **after** folders 3 and 7 — specific note sharing and shared tasks require an active friendship
 - Resume upload requires a real PDF file — select it manually via the file chooser in Postman
 - The AI Feedback request (Resumes) takes 2-5 seconds — this is normal (Groq API call)
+
+---
+
+# Postman Testing — Session 6
+
+API-20 through API-21: Messaging (Conversations + Messages).
+
+---
+
+## Setup
+
+### 1. Import the collection
+- Open Postman → **Collections** tab → **Import** → select `continuum-session6.postman_collection.json`
+- The environment (`continuum-local.postman_environment.json`) is shared — re-import it to pick up the new variables, or re-use the existing one
+
+### 2. Select the environment
+- Top-right corner of Postman — switch the dropdown to **Continuum — Local**
+
+### 3. Start the backend server
+```bash
+cd backend && npm run dev
+```
+
+---
+
+## Environment Variables
+
+New variables added for session 6. All are auto-set by test scripts.
+
+| Variable         | Set by                  | Used by                                    |
+|------------------|-------------------------|--------------------------------------------|
+| `conversationId` | Start Conversation      | Send Message, Get Messages, Mark as Read   |
+| `messageId`      | Send Message — User 1   | Mark as Read                               |
+| `messageSentAt`  | Send Message — User 1   | Get Messages — Paginated (`before` cursor) |
+
+---
+
+## Test Order
+
+Run folders top to bottom.
+
+### 0. Setup — Second User
+*(Run these first, in order)*
+
+| Request | Body Input | Expected | Tested |
+|---------|------------|----------|--------|
+| Login User 1 | `{ "email", "password" }` | `200` — sets `token` + `userId` | ✅ |
+| Login User 2 | `{ "email", "password" }` | `200` — sets `secondToken` + `secondUserId` | ✅ |
+
+### 1. Conversations
+| Request | Body Input | Expected | Tested |
+|---------|------------|----------|--------|
+| Start Conversation | `{ "participantId": "{{secondUserId}}" }` | `201` — sets `conversationId`, participants populated | ✅ |
+| Start Conversation Again — Idempotent | `{ "participantId": "{{secondUserId}}" }` | `200` — returns existing conversation | ✅ |
+| Get Inbox | none | `200` — conversation appears in array | ✅ |
+
+### 2. Messages
+| Request | Body Input | Expected | Tested |
+|---------|------------|----------|--------|
+| Send Message — User 1 | `{ "content": "..." }` | `201` — sets `messageId` + `messageSentAt`, check `lastMessage` on conversation | ✅ |
+| Send Message — User 2 | `{ "content": "..." }` | `201` — check User 1's `unreadCounts` incremented | ✅ |
+| Get Messages | none | `200` — both messages in array (newest first), check `hasMore: false` | ✅ |
+| Get Messages — Paginated | query: `?limit=1&before={{messageSentAt}}` | `200` — cursor working, empty array when no older messages exist | ✅ |
+| Mark as Read — User 1 | none | `200` — check `readBy` includes User 1, unread count reset to `0` | ✅ |
+| Get Inbox — Verify lastMessage Updated | none | `200` — `lastMessage.content` matches last sent message | ✅ |
+
+### 3. Error Cases
+| Request | Body Input | Expected | Tested |
+|---------|------------|----------|--------|
+| [Error] Start Conversation — Missing participantId | `{}` | `400` | ✅ |
+| [Error] Start Conversation — Send to Self | `{ "participantId": "{{userId}}" }` | `400` | ✅ |
+| [Error] Send Message — Empty Content | `{ "content": "" }` | `400` | ✅ |
+| [Error] Get Messages — No Token | none | `401` | ✅ |
+| [Error] Mark as Read — Not Found | none | `404` | ✅ |
+
+---
+
+## Tips
+
+- Run folder **0. Setup** first every time — both users need fresh tokens
+- `messageSentAt` is the `createdAt` of User 1's first message — used as the `before` cursor for pagination testing
+- User 2 is already registered from session 5 — use **Login User 2** instead of Register

--- a/backend/testing/postman/continuum-local.postman_environment.json
+++ b/backend/testing/postman/continuum-local.postman_environment.json
@@ -17,8 +17,11 @@
     { "key": "resumeId",        "value": "",                      "type": "default", "enabled": true },
     { "key": "applicationId",   "value": "",                      "type": "default", "enabled": true },
     { "key": "sharedTaskId",    "value": "",                      "type": "default", "enabled": true },
-    { "key": "calFrom",         "value": "",                      "type": "default", "enabled": true },
-    { "key": "calTo",           "value": "",                      "type": "default", "enabled": true }
+    { "key": "calFrom",           "value": "",                      "type": "default", "enabled": true },
+    { "key": "calTo",             "value": "",                      "type": "default", "enabled": true },
+    { "key": "conversationId",    "value": "",                      "type": "default", "enabled": true },
+    { "key": "messageId",         "value": "",                      "type": "default", "enabled": true },
+    { "key": "messageSentAt",     "value": "",                      "type": "default", "enabled": true }
   ],
   "_postman_variable_scope": "environment"
 }

--- a/backend/testing/postman/continuum-session6.postman_collection.json
+++ b/backend/testing/postman/continuum-session6.postman_collection.json
@@ -1,0 +1,359 @@
+{
+  "info": {
+    "_postman_id": "d4e5f6a7-b8c9-0123-defa-123456789003",
+    "name": "Continuum — Session 6",
+    "description": "API-20 through API-21: Messaging (Conversations + Messages).\n\nRun order: 0. Setup → 1. Conversations → 2. Messages → 3. Error Cases.\nToken + IDs are auto-set by test scripts — run Login User 1 first.",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "auth": {
+    "type": "bearer",
+    "bearer": [
+      { "key": "token", "value": "{{token}}", "type": "string" }
+    ]
+  },
+  "item": [
+    {
+      "name": "0. Setup — Second User",
+      "item": [
+        {
+          "name": "Login User 1",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if (pm.response.code === 200) {",
+                  "    const json = pm.response.json();",
+                  "    pm.environment.set('token', json.token);",
+                  "    pm.environment.set('userId', json.user._id);",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "auth": { "type": "noauth" },
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"email\": \"test@example.com\",\n  \"password\": \"Password123!\"\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/auth/login",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "auth", "login"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Login User 2",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if (pm.response.code === 200) {",
+                  "    const json = pm.response.json();",
+                  "    pm.environment.set('secondToken', json.token);",
+                  "    pm.environment.set('secondUserId', json.user._id);",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "auth": { "type": "noauth" },
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"email\": \"test2@example.com\",\n  \"password\": \"Password123!\"\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/auth/login",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "auth", "login"]
+            }
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "1. Conversations",
+      "item": [
+        {
+          "name": "Start Conversation",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if (pm.response.code === 201) {",
+                  "    const json = pm.response.json();",
+                  "    pm.environment.set('conversationId', json.conversation._id);",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"participantId\": \"{{secondUserId}}\"\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/conversations",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "conversations"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Start Conversation Again — Idempotent",
+          "request": {
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"participantId\": \"{{secondUserId}}\"\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/conversations",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "conversations"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Get Inbox",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/api/conversations",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "conversations"]
+            }
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "2. Messages",
+      "item": [
+        {
+          "name": "Send Message — User 1",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if (pm.response.code === 201) {",
+                  "    const json = pm.response.json();",
+                  "    pm.environment.set('messageId', json.message._id);",
+                  "    pm.environment.set('messageSentAt', json.message.createdAt);",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"content\": \"Hey! Are you free to study later?\"\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/conversations/{{conversationId}}/messages",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "conversations", "{{conversationId}}", "messages"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Send Message — User 2",
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [{ "key": "token", "value": "{{secondToken}}", "type": "string" }]
+            },
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"content\": \"Yeah, 3pm works for me!\"\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/conversations/{{conversationId}}/messages",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "conversations", "{{conversationId}}", "messages"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Get Messages",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/api/conversations/{{conversationId}}/messages",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "conversations", "{{conversationId}}", "messages"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Get Messages — Paginated",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/api/conversations/{{conversationId}}/messages?limit=1&before={{messageSentAt}}",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "conversations", "{{conversationId}}", "messages"],
+              "query": [
+                { "key": "limit", "value": "1" },
+                { "key": "before", "value": "{{messageSentAt}}" }
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Mark as Read — User 1",
+          "request": {
+            "method": "PUT",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/api/messages/{{messageId}}/read",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "messages", "{{messageId}}", "read"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Get Inbox — Verify lastMessage Updated",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/api/conversations",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "conversations"]
+            }
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "3. Error Cases",
+      "item": [
+        {
+          "name": "[Error] Start Conversation — Missing participantId",
+          "request": {
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": {
+              "mode": "raw",
+              "raw": "{}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/conversations",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "conversations"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "[Error] Start Conversation — Send to Self",
+          "request": {
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"participantId\": \"{{userId}}\"\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/conversations",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "conversations"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "[Error] Send Message — Empty Content",
+          "request": {
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"content\": \"\"\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/conversations/{{conversationId}}/messages",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "conversations", "{{conversationId}}", "messages"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "[Error] Get Messages — No Token",
+          "request": {
+            "auth": { "type": "noauth" },
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/api/conversations/{{conversationId}}/messages",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "conversations", "{{conversationId}}", "messages"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "[Error] Mark as Read — Not Found",
+          "request": {
+            "method": "PUT",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/api/messages/000000000000000000000000/read",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "messages", "000000000000000000000000", "read"]
+            }
+          },
+          "response": []
+        }
+      ]
+    }
+  ]
+}

--- a/docs/master_planning_doc.md
+++ b/docs/master_planning_doc.md
@@ -408,7 +408,7 @@ API-20. [x] `feat: add stretch api endpoints (messaging)` *(stretch)*
    - GET /api/conversations/:id/messages — get messages (paginated)
    - PUT /api/messages/:id/read — mark as read
 
-API-21. [ ] `test: test stretch api endpoints with postman` *(stretch)*
+API-21. [x] `test: test stretch api endpoints with postman` *(stretch)*
    - Create Postman collection for stretch messaging endpoints
    - Test conversation creation and message sending flow end-to-end
    - Test message pagination and read receipts


### PR DESCRIPTION
## Summary
- Created `continuum-session6.postman_collection.json` with full messaging test suite (API-21)
- Added `conversationId`, `messageId`, `messageSentAt` to the shared environment file
- Updated README with session 6 setup, environment variables, and full test order table

Closes #69