### PR TITLE
fix: session management polish

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -14,6 +14,10 @@ const passport = require('./config/passport');
 
 const app = express();
 
+// Trust the first proxy hop (Render's load balancer) so req.ip returns the real client IP
+// from the X-Forwarded-For header rather than the load balancer's internal address.
+app.set('trust proxy', 1);
+
 // Suppress HTTP request logs during tests
 if (process.env.NODE_ENV !== 'test') {
   app.use(pinoHttp({ logger }));

--- a/backend/controllers/auth.controller.js
+++ b/backend/controllers/auth.controller.js
@@ -9,7 +9,7 @@ const googleClient = new OAuth2Client(process.env.GOOGLE_CLIENT_ID);
 const jwt = require('jsonwebtoken');
 const { Resend } = require('resend');
 const cloudinary = require('../config/cloudinary');
-const { invalidate } = require('../lib/cache');
+const { invalidate, setKey } = require('../lib/cache');
 const { hardDeleteUser } = require('../services/account.service');
 
 const resend = new Resend(process.env.RESEND_API_KEY);
@@ -50,9 +50,13 @@ function emailTemplate(content) {
 // ----------------------------------------
 // HELPER: Sign a short-lived JWT access token (1d)
 // tokenVersion is embedded so auth middleware can immediately reject stale tokens after logoutAll
+// sessionId (the RefreshToken _id) is embedded so middleware can immediately reject
+// individually revoked sessions via the Redis blocklist
 // ----------------------------------------
-const signToken = (userId, tokenVersion = 0) => {
-    return jwt.sign({ userId, tokenVersion }, process.env.JWT_SECRET, { expiresIn: process.env.JWT_EXPIRES_IN || '1d', algorithm: 'HS256' });
+const signToken = (userId, tokenVersion = 0, sessionId = null) => {
+    const payload = { userId, tokenVersion };
+    if (sessionId) payload.sessionId = String(sessionId);
+    return jwt.sign(payload, process.env.JWT_SECRET, { expiresIn: process.env.JWT_EXPIRES_IN || '1d', algorithm: 'HS256' });
 };
 
 // ----------------------------------------
@@ -71,36 +75,69 @@ const setRefreshCookie = (res, rawToken) => {
 // ----------------------------------------
 // HELPER: Generate a long-lived refresh token (30d)
 // Stores a SHA-256 hash in the RefreshToken collection
-// Returns the raw token to give to the client — never stored raw
+// Returns { rawToken, sessionId } — rawToken is set as httpOnly cookie, sessionId is embedded in JWT
 // ----------------------------------------
-const generateRefreshToken = async (userId, deviceId) => {
+const generateRefreshToken = async (userId, deviceId, ipAddress = null) => {
     const rawToken = crypto.randomBytes(40).toString('hex');
     const tokenHash = crypto.createHash('sha256').update(rawToken).digest('hex');
     const expiresAt = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000); // 30 days
 
-    await RefreshToken.create({ userId, tokenHash, deviceId: deviceId || null, expiresAt });
+    const doc = await RefreshToken.create({ userId, tokenHash, deviceId: deviceId || null, ipAddress: ipAddress || null, expiresAt });
 
-    return rawToken;
+    return { rawToken, sessionId: doc._id };
 };
 
 // ----------------------------------------
 // HELPER: Parse a human-readable device label from a User-Agent string
-// e.g. "Chrome on Mac", "Firefox on Windows", "Safari on iOS"
+// e.g. "Chrome 120 on macOS", "Safari 17 on iPhone (iOS 17)", "Firefox 121 on Windows"
 // ----------------------------------------
 const parseDeviceLabel = (ua = '') => {
     if (!ua) return 'Unknown device';
-    const browser =
-        /Edg\//.test(ua) ? 'Edge' :
-        /OPR\/|Opera/.test(ua) ? 'Opera' :
-        /Chrome\//.test(ua) ? 'Chrome' :
-        /Firefox\//.test(ua) ? 'Firefox' :
-        /Safari\//.test(ua) && !/Chrome/.test(ua) ? 'Safari' : 'Browser';
-    const os =
-        /iPhone|iPad/.test(ua) ? 'iOS' :
-        /Android/.test(ua) ? 'Android' :
-        /Windows/.test(ua) ? 'Windows' :
-        /Mac OS X/.test(ua) ? 'Mac' :
-        /Linux/.test(ua) ? 'Linux' : 'Unknown OS';
+
+    // Browser + major version
+    let browser = 'Browser';
+    let browserMatch;
+    if (/Edg\/(\d+)/.test(ua)) {
+        browser = `Edge ${ua.match(/Edg\/(\d+)/)[1]}`;
+    } else if (/OPR\/(\d+)|Opera\/(\d+)/.test(ua)) {
+        browserMatch = ua.match(/OPR\/(\d+)/) || ua.match(/Opera\/(\d+)/);
+        browser = `Opera ${browserMatch[1]}`;
+    } else if (/Firefox\/(\d+)/.test(ua)) {
+        browser = `Firefox ${ua.match(/Firefox\/(\d+)/)[1]}`;
+    } else if (/Chrome\/(\d+)/.test(ua) && !/Chromium/.test(ua)) {
+        browser = `Chrome ${ua.match(/Chrome\/(\d+)/)[1]}`;
+    } else if (/Version\/(\d+).*Safari/.test(ua) && !/Chrome/.test(ua)) {
+        browser = `Safari ${ua.match(/Version\/(\d+)/)[1]}`;
+    } else if (/Safari\//.test(ua) && !/Chrome/.test(ua)) {
+        browser = 'Safari';
+    }
+
+    // Device type + OS
+    let device = '';
+    let os = 'Unknown OS';
+    if (/iPhone/.test(ua)) {
+        device = 'iPhone';
+        const iosMatch = ua.match(/CPU iPhone OS ([\d_]+)/);
+        os = iosMatch ? `iOS ${iosMatch[1].replace(/_/g, '.')}` : 'iOS';
+    } else if (/iPad/.test(ua)) {
+        device = 'iPad';
+        const iosMatch = ua.match(/CPU OS ([\d_]+)/);
+        os = iosMatch ? `iOS ${iosMatch[1].replace(/_/g, '.')}` : 'iPadOS';
+    } else if (/Android/.test(ua)) {
+        const androidMatch = ua.match(/Android ([\d.]+)/);
+        os = androidMatch ? `Android ${androidMatch[1]}` : 'Android';
+    } else if (/Windows NT ([\d.]+)/.test(ua)) {
+        const ntMap = { '10.0': '10/11', '6.3': '8.1', '6.2': '8', '6.1': '7' };
+        const ntVer = ua.match(/Windows NT ([\d.]+)/)[1];
+        os = `Windows ${ntMap[ntVer] || ntVer}`;
+    } else if (/Mac OS X ([\d_]+)/.test(ua)) {
+        const macMatch = ua.match(/Mac OS X ([\d_]+)/);
+        os = `macOS ${macMatch[1].replace(/_/g, '.')}`;
+    } else if (/Linux/.test(ua)) {
+        os = 'Linux';
+    }
+
+    if (device) return `${browser} on ${device} (${os})`;
     return `${browser} on ${os}`;
 };
 
@@ -128,8 +165,12 @@ exports.register = async (req, res) => {
     if (teamEmails.includes(email.toLowerCase())) assignedRoles.push('team');
     if (assignedRoles.length) await User.updateOne({ _id: user._id }, { roles: assignedRoles });
 
-    const token = signToken(user._id, user.tokenVersion);
-    const refreshToken = await generateRefreshToken(user._id, parseDeviceLabel(req.headers['user-agent']));
+    const { rawToken: refreshToken, sessionId } = await generateRefreshToken(
+        user._id,
+        parseDeviceLabel(req.headers['user-agent']),
+        req.ip || null
+    );
+    const token = signToken(user._id, user.tokenVersion, sessionId);
 
     // Auto-send verification email — non-blocking, don't fail registration if it errors
     try {
@@ -197,8 +238,12 @@ exports.login = async (req, res) => {
 
     await user.save();
 
-    const token = signToken(user._id, user.tokenVersion);
-    const refreshToken = await generateRefreshToken(user._id, parseDeviceLabel(req.headers['user-agent']));
+    const { rawToken: refreshToken, sessionId } = await generateRefreshToken(
+        user._id,
+        parseDeviceLabel(req.headers['user-agent']),
+        req.ip || null
+    );
+    const token = signToken(user._id, user.tokenVersion, sessionId);
 
     const userObj = user.toObject();
     delete userObj.password;
@@ -334,8 +379,12 @@ exports.googleExchange = async (req, res) => {
         return res.status(401).json({ success: false, error: 'User not found' });
     }
 
-    const token = signToken(user._id, user.tokenVersion);
-    const refreshToken = await generateRefreshToken(record.userId, parseDeviceLabel(req.headers['user-agent']));
+    const { rawToken: refreshToken, sessionId } = await generateRefreshToken(
+        record.userId,
+        parseDeviceLabel(req.headers['user-agent']),
+        req.ip || null
+    );
+    const token = signToken(user._id, user.tokenVersion, sessionId);
 
     setRefreshCookie(res, refreshToken);
     res.status(200).json({ success: true, token });
@@ -443,7 +492,11 @@ exports.refresh = async (req, res) => {
         return res.status(401).json({ success: false, error: 'User not found' });
     }
 
-    const token = signToken(stored.userId, user.tokenVersion);
+    // Track when this session was last used to issue a new JWT
+    stored.lastUsedAt = new Date();
+    await stored.save();
+
+    const token = signToken(stored.userId, user.tokenVersion, stored._id);
 
     res.status(200).json({ success: true, token });
 };
@@ -582,11 +635,21 @@ exports.logoutAll = async (req, res) => {
 // Purpose: Return all active (non-revoked, non-expired) sessions for the current user
 // ----------------------------------------
 exports.getSessions = async (req, res) => {
-    const sessions = await RefreshToken.find({
+    const tokens = await RefreshToken.find({
         userId: req.user._id,
         revokedAt: null,
         expiresAt: { $gt: new Date() },
-    }).select('_id deviceId createdAt').sort({ createdAt: -1 });
+    }).select('_id deviceId ipAddress lastUsedAt createdAt').sort({ createdAt: -1 });
+
+    const sessions = tokens.map((t) => ({
+        _id: t._id,
+        deviceId: t.deviceId,
+        ipAddress: t.ipAddress,
+        lastUsedAt: t.lastUsedAt,
+        createdAt: t.createdAt,
+        isCurrent: req.sessionId ? String(t._id) === req.sessionId : false,
+    }));
+
     res.status(200).json({ success: true, sessions });
 };
 
@@ -605,6 +668,13 @@ exports.revokeSession = async (req, res) => {
     }
     session.revokedAt = new Date();
     await session.save();
+
+    // Write a Redis blocklist key so any existing JWT for this session is rejected
+    // immediately by auth middleware — not just on next refresh attempt.
+    // TTL matches JWT expiry (default 1 day). Fail-open: skip if Redis unavailable.
+    const jwtTtlSeconds = parseInt(process.env.JWT_EXPIRES_SECONDS, 10) || 86400;
+    await setKey(`revoked_session:${session._id}`, jwtTtlSeconds);
+
     res.status(200).json({ success: true });
 };
 

--- a/backend/controllers/auth.controller.js
+++ b/backend/controllers/auth.controller.js
@@ -1,4 +1,5 @@
 const crypto = require('crypto');
+const geoip = require('geoip-lite');
 const { OAuth2Client } = require('google-auth-library');
 const User = require('../models/User');
 const Note = require('../models/Note');
@@ -77,12 +78,12 @@ const setRefreshCookie = (res, rawToken) => {
 // Stores a SHA-256 hash in the RefreshToken collection
 // Returns { rawToken, sessionId } — rawToken is set as httpOnly cookie, sessionId is embedded in JWT
 // ----------------------------------------
-const generateRefreshToken = async (userId, deviceId, ipAddress = null) => {
+const generateRefreshToken = async (userId, deviceId, ipAddress = null, ipLocation = null) => {
     const rawToken = crypto.randomBytes(40).toString('hex');
     const tokenHash = crypto.createHash('sha256').update(rawToken).digest('hex');
     const expiresAt = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000); // 30 days
 
-    const doc = await RefreshToken.create({ userId, tokenHash, deviceId: deviceId || null, ipAddress: ipAddress || null, expiresAt });
+    const doc = await RefreshToken.create({ userId, tokenHash, deviceId: deviceId || null, ipAddress: ipAddress || null, ipLocation: ipLocation || null, expiresAt });
 
     return { rawToken, sessionId: doc._id };
 };
@@ -142,6 +143,24 @@ const parseDeviceLabel = (ua = '') => {
 };
 
 // ----------------------------------------
+// HELPER: Resolve a client IP to a human-readable location string
+// Returns "City, ST" (US) or "City, Country" (elsewhere), or null for loopback/private/unknown
+// ----------------------------------------
+const LOOPBACK_IPS = new Set(['::1', '127.0.0.1', '::ffff:127.0.0.1']);
+const resolveLocation = (ip) => {
+    if (!ip) return null;
+    const normalized = ip.startsWith('::ffff:') ? ip.slice(7) : ip;
+    if (LOOPBACK_IPS.has(normalized)) return null;
+    const geo = geoip.lookup(normalized);
+    if (!geo) return null;
+    const parts = [];
+    if (geo.city) parts.push(geo.city);
+    if (geo.country === 'US' && geo.region) parts.push(geo.region);
+    else if (geo.country) parts.push(geo.country);
+    return parts.join(', ') || null;
+};
+
+// ----------------------------------------
 // POST /api/auth/register
 // Purpose: Create a new user and return a JWT
 // ----------------------------------------
@@ -165,10 +184,12 @@ exports.register = async (req, res) => {
     if (teamEmails.includes(email.toLowerCase())) assignedRoles.push('team');
     if (assignedRoles.length) await User.updateOne({ _id: user._id }, { roles: assignedRoles });
 
+    const regIp = req.ip || null;
     const { rawToken: refreshToken, sessionId } = await generateRefreshToken(
         user._id,
         parseDeviceLabel(req.headers['user-agent']),
-        req.ip || null
+        regIp,
+        resolveLocation(regIp)
     );
     const token = signToken(user._id, user.tokenVersion, sessionId);
 
@@ -238,10 +259,12 @@ exports.login = async (req, res) => {
 
     await user.save();
 
+    const loginIp = req.ip || null;
     const { rawToken: refreshToken, sessionId } = await generateRefreshToken(
         user._id,
         parseDeviceLabel(req.headers['user-agent']),
-        req.ip || null
+        loginIp,
+        resolveLocation(loginIp)
     );
     const token = signToken(user._id, user.tokenVersion, sessionId);
 
@@ -379,10 +402,12 @@ exports.googleExchange = async (req, res) => {
         return res.status(401).json({ success: false, error: 'User not found' });
     }
 
+    const oauthIp = req.ip || null;
     const { rawToken: refreshToken, sessionId } = await generateRefreshToken(
         record.userId,
         parseDeviceLabel(req.headers['user-agent']),
-        req.ip || null
+        oauthIp,
+        resolveLocation(oauthIp)
     );
     const token = signToken(user._id, user.tokenVersion, sessionId);
 
@@ -639,12 +664,12 @@ exports.getSessions = async (req, res) => {
         userId: req.user._id,
         revokedAt: null,
         expiresAt: { $gt: new Date() },
-    }).select('_id deviceId ipAddress lastUsedAt createdAt').sort({ createdAt: -1 });
+    }).select('_id deviceId ipAddress ipLocation lastUsedAt createdAt').sort({ createdAt: -1 });
 
     const sessions = tokens.map((t) => ({
         _id: t._id,
         deviceId: t.deviceId,
-        ipAddress: t.ipAddress,
+        ipLocation: t.ipLocation,
         lastUsedAt: t.lastUsedAt,
         createdAt: t.createdAt,
         isCurrent: req.sessionId ? String(t._id) === req.sessionId : false,

--- a/backend/lib/cache.js
+++ b/backend/lib/cache.js
@@ -116,4 +116,35 @@ async function checkAiLimit(userId, limit, type) {
     }
 }
 
-module.exports = { getOrSet, invalidate, invalidatePattern, checkAiLimit };
+/**
+ * Set a key to '1' with a TTL (used for blocklists, e.g. revoked sessions).
+ * No-op if Redis is unavailable.
+ *
+ * @param {string} key
+ * @param {number} ttlSeconds
+ */
+async function setKey(key, ttlSeconds) {
+    const c = await getClient();
+    if (!c) return;
+    try {
+        await c.setEx(key, ttlSeconds, '1');
+    } catch (_) {}
+}
+
+/**
+ * Get the raw string value of a key, or null if missing/unavailable.
+ *
+ * @param {string} key
+ * @returns {Promise<string|null>}
+ */
+async function getKey(key) {
+    const c = await getClient();
+    if (!c) return null;
+    try {
+        return await c.get(key);
+    } catch (_) {
+        return null;
+    }
+}
+
+module.exports = { getOrSet, invalidate, invalidatePattern, checkAiLimit, setKey, getKey };

--- a/backend/middleware/auth.middleware.js
+++ b/backend/middleware/auth.middleware.js
@@ -1,6 +1,7 @@
 const jwt = require('jsonwebtoken');
 const User = require('../models/User');
 const { getOrSet, invalidate } = require('../lib/cache');
+const cache = require('../lib/cache');
 const { hardDeleteUser } = require('../services/account.service');
 
 // ============================================================
@@ -43,6 +44,16 @@ const authMiddleware = async (req, res, next) => {
     // Reject stale tokens invalidated by logoutAll — tokenVersion in JWT must match DB
     if (decoded.tokenVersion !== undefined && decoded.tokenVersion !== user.tokenVersion) {
         return res.status(401).json({ success: false, error: 'Session invalidated.' });
+    }
+
+    // Reject individually revoked sessions — check Redis blocklist written by revokeSession.
+    // Fail-open: if Redis is unavailable, getKey returns null and we proceed normally.
+    if (decoded.sessionId) {
+        const revoked = await cache.getKey(`revoked_session:${decoded.sessionId}`);
+        if (revoked) {
+            return res.status(401).json({ success: false, error: 'Session revoked.' });
+        }
+        req.sessionId = decoded.sessionId;
     }
 
     // Handle pending deletion grace period

--- a/backend/models/RefreshToken.js
+++ b/backend/models/RefreshToken.js
@@ -5,7 +5,8 @@ const mongoose = require('mongoose');
 // Purpose: Store long-lived refresh tokens for multi-device JWT auth
 // Collection: refreshtokens
 // Features: Per-device token tracking, revocation on logout,
-//           bulk revocation via logout-all, 30d expiry
+//           bulk revocation via logout-all, 30d expiry,
+//           immediate per-session revocation via Redis blocklist
 // Note: Raw token is NEVER stored — only SHA-256 hash.
 //       Same pattern as passwordResetToken in User.js.
 // ============================================================
@@ -37,12 +38,29 @@ const refreshTokenSchema = new mongoose.Schema({
     /**
      * Device Info
      * Purpose: Optionally label which device this token belongs to
-     * Fields: deviceId
-     * Note: Client can pass "iPhone 14" or "Chrome on Mac" at login.
-     *       Used for future "manage devices" UI — not functional auth logic.
+     * Fields: deviceId, ipAddress
+     * Note: deviceId is parsed from User-Agent (e.g. "Chrome 120 on macOS").
+     *       ipAddress is the client IP captured at login/register.
+     *       Both are used in the "manage sessions" UI.
      */
     deviceId: {
         type: String,
+        default: null,
+    },
+
+    ipAddress: {
+        type: String,
+        default: null,
+    },
+
+    /**
+     * Last Used
+     * Purpose: Track when this token was last used to issue a new JWT
+     * Fields: lastUsedAt
+     * Note: Updated on every successful POST /auth/refresh call.
+     */
+    lastUsedAt: {
+        type: Date,
         default: null,
     },
 

--- a/backend/models/RefreshToken.js
+++ b/backend/models/RefreshToken.js
@@ -54,6 +54,18 @@ const refreshTokenSchema = new mongoose.Schema({
     },
 
     /**
+     * Resolved Location
+     * Purpose: Human-readable city/country derived from ipAddress at login time
+     * Fields: ipLocation
+     * Note: Resolved via geoip-lite local DB. Null for loopback/private IPs or unknown addresses.
+     *       Stored as "City, ST" (US) or "City, Country" (elsewhere).
+     */
+    ipLocation: {
+        type: String,
+        default: null,
+    },
+
+    /**
      * Last Used
      * Purpose: Track when this token was last used to issue a new JWT
      * Fields: lastUsedAt

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -20,6 +20,7 @@
         "dotenv": "^17.2.3",
         "express": "^5.2.1",
         "express-rate-limit": "^8.3.1",
+        "geoip-lite": "^1.4.10",
         "google-auth-library": "^10.6.2",
         "googleapis": "^171.4.0",
         "groq-sdk": "^0.37.0",
@@ -2990,7 +2991,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -3051,6 +3051,15 @@
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/async": {
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.14"
+      }
     },
     "node_modules/async-mutex": {
       "version": "0.5.0",
@@ -3450,7 +3459,6 @@
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "*"
@@ -3626,7 +3634,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -3792,7 +3799,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -3805,7 +3811,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/colorette": {
@@ -4655,6 +4660,15 @@
         "bser": "2.1.1"
       }
     },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
+      }
+    },
     "node_modules/fetch-blob": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
@@ -4968,6 +4982,66 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/geoip-lite": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/geoip-lite/-/geoip-lite-1.4.10.tgz",
+      "integrity": "sha512-4N69uhpS3KFd97m00wiFEefwa+L+HT5xZbzPhwu+sDawStg6UN/dPwWtUfkQuZkGIY1Cj7wDVp80IsqNtGMi2w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "async": "2.1 - 2.6.4",
+        "chalk": "4.1 - 4.1.2",
+        "iconv-lite": "0.4.13 - 0.6.3",
+        "ip-address": "5.8.9 - 5.9.4",
+        "lazy": "1.0.11",
+        "rimraf": "2.5.2 - 2.7.1",
+        "yauzl": "2.9.2 - 2.10.0"
+      },
+      "engines": {
+        "node": ">=10.3.0"
+      }
+    },
+    "node_modules/geoip-lite/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/geoip-lite/node_modules/ip-address": {
+      "version": "5.9.4",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-5.9.4.tgz",
+      "integrity": "sha512-dHkI3/YNJq4b/qQaz+c8LuarD3pY24JqZWfjB8aZx1gtpc2MDILu9L9jpZe1sHpzo/yWFweQVn+U//FhazUxmw==",
+      "license": "MIT",
+      "dependencies": {
+        "jsbn": "1.1.0",
+        "lodash": "^4.17.15",
+        "sprintf-js": "1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/geoip-lite/node_modules/sprintf-js": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+      "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/geoip-lite/node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
+    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -5208,7 +5282,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6239,6 +6312,12 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsbn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
+      "license": "MIT"
+    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -6331,6 +6410,15 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/lazy": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/lazy/-/lazy-1.0.11.tgz",
+      "integrity": "sha512-Y+CjUfLmIpoUCCRl0ub4smrYtGGr5AOa2AKOaWelGHOGz33X/Y/KizefGqbkwfz44+cnq/+9habclf8vOmu2LA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.2.0"
       }
     },
     "node_modules/leven": {
@@ -7389,7 +7477,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
       "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/pg-int8": {
@@ -7883,6 +7970,62 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/rimraf/node_modules/brace-expansion": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/rimraf/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/router": {
@@ -8593,7 +8736,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"

--- a/backend/package.json
+++ b/backend/package.json
@@ -38,6 +38,7 @@
     "dotenv": "^17.2.3",
     "express": "^5.2.1",
     "express-rate-limit": "^8.3.1",
+    "geoip-lite": "^1.4.10",
     "google-auth-library": "^10.6.2",
     "googleapis": "^171.4.0",
     "groq-sdk": "^0.37.0",

--- a/backend/routes/auth.routes.js
+++ b/backend/routes/auth.routes.js
@@ -281,8 +281,8 @@ router.post('/logout-all', authMiddleware, authController.logoutAll);
  *     description: >
  *       Returns all non-revoked, non-expired RefreshToken records.
  *       Each session includes a human-readable device label (browser + version + OS),
- *       the client IP at login, last active timestamp, and an isCurrent flag
- *       marking the session that issued the request's JWT.
+ *       a human-readable location resolved from the client IP at login (e.g. "San Francisco, CA"),
+ *       last active timestamp, and an isCurrent flag marking the session that issued the request's JWT.
  *     tags: [Auth]
  *     responses:
  *       200:
@@ -300,7 +300,7 @@ router.post('/logout-all', authMiddleware, authController.logoutAll);
  *                     properties:
  *                       _id:         { type: string }
  *                       deviceId:    { type: string, example: "Chrome 120 on macOS 10.15.7" }
- *                       ipAddress:   { type: string, example: "203.0.113.42", nullable: true }
+ *                       ipLocation:  { type: string, example: "San Francisco, CA", nullable: true, description: "City and state/country resolved from login IP; null for local/unknown IPs" }
  *                       lastUsedAt:  { type: string, format: date-time, nullable: true }
  *                       createdAt:   { type: string, format: date-time }
  *                       isCurrent:   { type: boolean, description: "True when this session issued the current request JWT" }

--- a/backend/routes/auth.routes.js
+++ b/backend/routes/auth.routes.js
@@ -278,7 +278,11 @@ router.post('/logout-all', authMiddleware, authController.logoutAll);
  * /api/auth/sessions:
  *   get:
  *     summary: List active sessions for the current user
- *     description: Returns all non-revoked, non-expired RefreshToken records with device label and creation date.
+ *     description: >
+ *       Returns all non-revoked, non-expired RefreshToken records.
+ *       Each session includes a human-readable device label (browser + version + OS),
+ *       the client IP at login, last active timestamp, and an isCurrent flag
+ *       marking the session that issued the request's JWT.
  *     tags: [Auth]
  *     responses:
  *       200:
@@ -294,9 +298,12 @@ router.post('/logout-all', authMiddleware, authController.logoutAll);
  *                   items:
  *                     type: object
  *                     properties:
- *                       _id:       { type: string }
- *                       deviceId:  { type: string, example: "Chrome on Mac" }
- *                       createdAt: { type: string, format: date-time }
+ *                       _id:         { type: string }
+ *                       deviceId:    { type: string, example: "Chrome 120 on macOS 10.15.7" }
+ *                       ipAddress:   { type: string, example: "203.0.113.42", nullable: true }
+ *                       lastUsedAt:  { type: string, format: date-time, nullable: true }
+ *                       createdAt:   { type: string, format: date-time }
+ *                       isCurrent:   { type: boolean, description: "True when this session issued the current request JWT" }
  *       401:
  *         $ref: '#/components/responses/Unauthorized'
  */

--- a/backend/tests/jest/auth.test.js
+++ b/backend/tests/jest/auth.test.js
@@ -386,7 +386,7 @@ describe('POST /api/auth/logout-all — refresh tokens revoked', () => {
 // ─── GET /auth/sessions ─────────────────────────────────────────────────────
 
 describe('GET /api/auth/sessions', () => {
-  it('returns active sessions for the current user', async () => {
+  it('returns active sessions with new fields and isCurrent for the current user', async () => {
     const reg = await request(app).post('/api/auth/register').send(validUser);
     const tokenA = reg.body.token;
 
@@ -403,9 +403,18 @@ describe('GET /api/auth/sessions', () => {
     expect(res.body.success).toBe(true);
     expect(Array.isArray(res.body.sessions)).toBe(true);
     expect(res.body.sessions.length).toBe(2);
-    expect(res.body.sessions[0]).toHaveProperty('_id');
-    expect(res.body.sessions[0]).toHaveProperty('deviceId');
-    expect(res.body.sessions[0]).toHaveProperty('createdAt');
+
+    const session = res.body.sessions[0];
+    expect(session).toHaveProperty('_id');
+    expect(session).toHaveProperty('deviceId');
+    expect(session).toHaveProperty('createdAt');
+    expect(session).toHaveProperty('ipAddress');
+    expect(session).toHaveProperty('lastUsedAt');
+    expect(session).toHaveProperty('isCurrent');
+
+    // Exactly one session should be marked as current (the one that issued tokenA)
+    const currentSessions = res.body.sessions.filter((s) => s.isCurrent);
+    expect(currentSessions).toHaveLength(1);
   });
 });
 
@@ -435,12 +444,50 @@ describe('DELETE /api/auth/sessions/:id', () => {
       .set('Cookie', cookie);
     expect(refreshRes.statusCode).toBe(401);
   });
+
+  it('immediately rejects the JWT for a revoked session when Redis blocklist is active', async () => {
+    // This test simulates the Redis blocklist path by spying on cache.getKey.
+    // In production with Redis running, revokeSession writes revoked_session:{id} and
+    // auth middleware checks it — any request using the old JWT is immediately rejected
+    // without waiting for the access token to expire.
+    const cache = require('../../lib/cache');
+
+    const reg = await request(app).post('/api/auth/register').send(validUser);
+    const token = reg.body.token;
+
+    const sessionsRes = await request(app)
+      .get('/api/auth/sessions')
+      .set('Authorization', `Bearer ${token}`);
+    const sessionId = sessionsRes.body.sessions[0]._id;
+
+    // Revoke the session
+    await request(app)
+      .delete(`/api/auth/sessions/${sessionId}`)
+      .set('Authorization', `Bearer ${token}`);
+
+    // Spy on cache.getKey to simulate Redis blocklist hit for this session
+    const spy = jest.spyOn(cache, 'getKey').mockImplementation(async (key) => {
+      if (key === `revoked_session:${sessionId}`) return '1';
+      return null;
+    });
+
+    try {
+      // The JWT is still within its expiry window, but the blocklist should cause 401
+      const meRes = await request(app)
+        .get('/api/auth/me')
+        .set('Authorization', `Bearer ${token}`);
+      expect(meRes.statusCode).toBe(401);
+      expect(meRes.body.error).toMatch(/revoked/i);
+    } finally {
+      spy.mockRestore();
+    }
+  });
 });
 
 // ─── Device label capture ───────────────────────────────────────────────────
 
 describe('Device label capture', () => {
-  it('stores a parsed device label on the RefreshToken after register', async () => {
+  it('stores a versioned device label and IP on the RefreshToken after register', async () => {
     const ua = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36';
 
     const reg = await request(app)
@@ -452,7 +499,25 @@ describe('Device label capture', () => {
     const token = await RefreshToken.findOne({ userId: reg.body.user._id });
     expect(token).not.toBeNull();
     expect(token.deviceId).toBeTruthy();
-    expect(token.deviceId).toContain('Chrome');
-    expect(token.deviceId).toContain('Mac');
+    // New format includes version number: "Chrome 124 on macOS 10.15.7"
+    expect(token.deviceId).toContain('Chrome 124');
+    expect(token.deviceId).toContain('macOS');
+    // ipAddress field is now stored (may be null/undefined in test env but field exists)
+    expect(Object.prototype.hasOwnProperty.call(token.toObject(), 'ipAddress')).toBe(true);
+  });
+
+  it('stores a correct label for iOS Safari', async () => {
+    const ua = 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1';
+
+    const reg = await request(app)
+      .post('/api/auth/register')
+      .set('User-Agent', ua)
+      .send(validUser);
+    expect(reg.statusCode).toBe(201);
+
+    const token = await RefreshToken.findOne({ userId: reg.body.user._id });
+    expect(token.deviceId).toContain('Safari 17');
+    expect(token.deviceId).toContain('iPhone');
+    expect(token.deviceId).toContain('iOS 17');
   });
 });

--- a/backend/tests/jest/auth.test.js
+++ b/backend/tests/jest/auth.test.js
@@ -408,7 +408,7 @@ describe('GET /api/auth/sessions', () => {
     expect(session).toHaveProperty('_id');
     expect(session).toHaveProperty('deviceId');
     expect(session).toHaveProperty('createdAt');
-    expect(session).toHaveProperty('ipAddress');
+    expect(session).toHaveProperty('ipLocation');
     expect(session).toHaveProperty('lastUsedAt');
     expect(session).toHaveProperty('isCurrent');
 
@@ -502,8 +502,9 @@ describe('Device label capture', () => {
     // New format includes version number: "Chrome 124 on macOS 10.15.7"
     expect(token.deviceId).toContain('Chrome 124');
     expect(token.deviceId).toContain('macOS');
-    // ipAddress field is now stored (may be null/undefined in test env but field exists)
+    // ipAddress and ipLocation fields are stored (both null in test env since req.ip is loopback)
     expect(Object.prototype.hasOwnProperty.call(token.toObject(), 'ipAddress')).toBe(true);
+    expect(Object.prototype.hasOwnProperty.call(token.toObject(), 'ipLocation')).toBe(true);
   });
 
   it('stores a correct label for iOS Safari', async () => {

--- a/docs/backend/api_reference_guide.md
+++ b/docs/backend/api_reference_guide.md
@@ -16,7 +16,7 @@
 - `POST /api/auth/refresh` - Exchange a valid refresh token for a new access token (public)
 - `POST /api/auth/logout` - Revoke current device's refresh token (protected)
 - `POST /api/auth/logout-all` - Immediately invalidate all sessions — increments `tokenVersion` so existing JWTs are rejected on the next request, then revokes all refresh tokens (protected)
-- `GET /api/auth/sessions` - List all active (non-revoked, non-expired) sessions for the current user. Response: `{ sessions: [{ _id, deviceId, ipAddress, lastUsedAt, createdAt, isCurrent }] }`. `isCurrent` is true for the session that issued the request's JWT (protected)
+- `GET /api/auth/sessions` - List all active (non-revoked, non-expired) sessions for the current user. Response: `{ sessions: [{ _id, deviceId, ipLocation, lastUsedAt, createdAt, isCurrent }] }`. `ipLocation` is a human-readable city/country (e.g. `"San Francisco, CA"`) resolved from the login IP via `geoip-lite`; null for local/unknown IPs. `isCurrent` is true for the session that issued the request's JWT (protected)
 - `DELETE /api/auth/sessions/:id` - Revoke a single session by RefreshToken `_id`. Immediately invalidates any active JWT for that session via a Redis blocklist key (`revoked_session:{id}`, TTL 1 day) — fail-open if Redis unavailable. Returns 404 if not found or already revoked (protected)
 - `GET /api/auth/google` - Initiate Google OAuth consent flow (login or registration)
 - `GET /api/auth/google/callback` - Handle OAuth callback, find/create user, return JWT

--- a/docs/backend/api_reference_guide.md
+++ b/docs/backend/api_reference_guide.md
@@ -15,14 +15,16 @@
 - `POST /api/auth/login` - Authenticate user, return JWT + refresh token
 - `POST /api/auth/refresh` - Exchange a valid refresh token for a new access token (public)
 - `POST /api/auth/logout` - Revoke current device's refresh token (protected)
-- `POST /api/auth/logout-all` - Revoke all active refresh tokens for the user (protected)
+- `POST /api/auth/logout-all` - Immediately invalidate all sessions — increments `tokenVersion` so existing JWTs are rejected on the next request, then revokes all refresh tokens (protected)
+- `GET /api/auth/sessions` - List all active (non-revoked, non-expired) sessions for the current user. Response: `{ sessions: [{ _id, deviceId, ipAddress, lastUsedAt, createdAt, isCurrent }] }`. `isCurrent` is true for the session that issued the request's JWT (protected)
+- `DELETE /api/auth/sessions/:id` - Revoke a single session by RefreshToken `_id`. Immediately invalidates any active JWT for that session via a Redis blocklist key (`revoked_session:{id}`, TTL 1 day) — fail-open if Redis unavailable. Returns 404 if not found or already revoked (protected)
 - `GET /api/auth/google` - Initiate Google OAuth consent flow (login or registration)
 - `GET /api/auth/google/callback` - Handle OAuth callback, find/create user, return JWT
 - `GET /api/auth/me` - Retrieve authenticated user from token
 - `POST /api/auth/forgot-password` - Send password reset email via Resend
 - `POST /api/auth/reset-password` - Verify reset token and set new password
 
-Users can register with email/password OR Google OAuth. Both paths create the same User document. Login and register return a short-lived JWT (1d) and a long-lived refresh token (30d). Each device gets its own refresh token — logout is per-device. `logout-all` revokes every active token for the user.
+Users can register with email/password OR Google OAuth. Both paths create the same User document. Login and register return a short-lived JWT (1d) and a long-lived refresh token (30d). Each device gets its own refresh token. The JWT payload includes `sessionId` (the RefreshToken `_id`) so per-session revocation takes effect immediately without waiting for token expiry. `logout-all` increments `tokenVersion` to immediately invalidate all sessions across all devices.
 
 ### **User Profile**
 - `PATCH /api/auth/me/profile` - Update user profile information (name, bio, avatarUrl, settings)

--- a/docs/database/mongodb_schema_explaination.md
+++ b/docs/database/mongodb_schema_explaination.md
@@ -825,7 +825,8 @@ Short-lived access tokens (1d) + long-lived refresh tokens (30d) stored as SHA-2
 
 Each `RefreshToken` document stores:
 - `deviceId` — human-readable label parsed from User-Agent (e.g. `"Chrome 120 on macOS 10.15.7"`, `"Safari 17 on iPhone (iOS 17)"`)
-- `ipAddress` — client IP captured at login/register
+- `ipAddress` — raw client IP captured at login/register
+- `ipLocation` — human-readable city/country resolved from `ipAddress` via `geoip-lite` at login time (e.g. `"San Francisco, CA"`, `"London, GB"`); null for loopback/private/unknown IPs. Displayed to users in the Security tab instead of the raw IP.
 - `lastUsedAt` — timestamp updated each time the token is used to issue a new JWT via `POST /auth/refresh`
 
 The JWT payload embeds `sessionId` (the `RefreshToken._id`). Auth middleware checks a Redis blocklist key `revoked_session:{sessionId}` (written by `DELETE /auth/sessions/:id`) to immediately reject active JWTs for revoked sessions — no need to wait for the 1-day access token expiry. This path is fail-open: if Redis is unavailable the check is skipped and the existing tokenVersion + revokedAt guards still apply. `logout-all` uses `tokenVersion` increment for immediate cross-device invalidation.

--- a/docs/database/mongodb_schema_explaination.md
+++ b/docs/database/mongodb_schema_explaination.md
@@ -822,3 +822,10 @@ Always validate input, scope queries by user, exclude sensitive fields, check au
 
 ### 8. **Multi-Device Auth via RefreshToken Collection**
 Short-lived access tokens (1d) + long-lived refresh tokens (30d) stored as SHA-256 hashes in a separate `RefreshToken` collection. Each device gets its own document — logout revokes one device, logout-all revokes all. Raw token is never stored.
+
+Each `RefreshToken` document stores:
+- `deviceId` — human-readable label parsed from User-Agent (e.g. `"Chrome 120 on macOS 10.15.7"`, `"Safari 17 on iPhone (iOS 17)"`)
+- `ipAddress` — client IP captured at login/register
+- `lastUsedAt` — timestamp updated each time the token is used to issue a new JWT via `POST /auth/refresh`
+
+The JWT payload embeds `sessionId` (the `RefreshToken._id`). Auth middleware checks a Redis blocklist key `revoked_session:{sessionId}` (written by `DELETE /auth/sessions/:id`) to immediately reject active JWTs for revoked sessions — no need to wait for the 1-day access token expiry. This path is fail-open: if Redis is unavailable the check is skipped and the existing tokenVersion + revokedAt guards still apply. `logout-all` uses `tokenVersion` increment for immediate cross-device invalidation.

--- a/docs/database/schema_diagram.md
+++ b/docs/database/schema_diagram.md
@@ -40,6 +40,7 @@ erDiagram
         String tokenHash "SHA-256 hash of raw token"
         String deviceId "browser + version + OS label e.g. Chrome 120 on macOS"
         String ipAddress "client IP at login/register, nullable"
+        String ipLocation "resolved city/country e.g. San Francisco, CA, nullable"
         Date lastUsedAt "updated on each POST /auth/refresh, nullable"
         Date expiresAt "30d from creation"
         Date revokedAt "null = active"

--- a/docs/database/schema_diagram.md
+++ b/docs/database/schema_diagram.md
@@ -38,7 +38,9 @@ erDiagram
         ObjectId _id PK
         ObjectId userId FK
         String tokenHash "SHA-256 hash of raw token"
-        String deviceId "optional device label"
+        String deviceId "browser + version + OS label e.g. Chrome 120 on macOS"
+        String ipAddress "client IP at login/register, nullable"
+        Date lastUsedAt "updated on each POST /auth/refresh, nullable"
         Date expiresAt "30d from creation"
         Date revokedAt "null = active"
         Date createdAt

--- a/web/src/pages/Profile.jsx
+++ b/web/src/pages/Profile.jsx
@@ -1168,18 +1168,37 @@ export default function Profile() {
               ) : (
                 <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
                   {sessionsData.map((s) => (
-                    <div key={s._id} style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12, padding: '8px 10px', background: '#faf7ff', borderRadius: 8 }}>
-                      <div>
-                        <p style={{ fontSize: 13, fontWeight: 600, color: '#111827', margin: 0 }}>{s.deviceId || 'Unknown device'}</p>
+                    <div key={s._id} style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12, padding: '8px 10px', background: s.isCurrent ? '#f5f0ff' : '#faf7ff', borderRadius: 8, border: s.isCurrent ? '1px solid #e9d5ff' : '1px solid transparent' }}>
+                      <div style={{ minWidth: 0 }}>
+                        <div style={{ display: 'flex', alignItems: 'center', gap: 6, flexWrap: 'wrap' }}>
+                          <p style={{ fontSize: 13, fontWeight: 600, color: '#111827', margin: 0 }}>{s.deviceId || 'Unknown device'}</p>
+                          {s.isCurrent && (
+                            <span style={{ fontSize: 10, fontWeight: 600, color: '#6b21a8', background: '#ede9fe', padding: '1px 6px', borderRadius: 10, whiteSpace: 'nowrap' }}>
+                              This device
+                            </span>
+                          )}
+                        </div>
                         <p style={{ fontSize: 11, color: '#a087b0', margin: '2px 0 0' }}>
                           Signed in {new Date(s.createdAt).toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' })}
+                          {s.lastUsedAt && (
+                            <> &middot; Last active {(() => {
+                              const diff = Date.now() - new Date(s.lastUsedAt).getTime();
+                              const mins = Math.floor(diff / 60000);
+                              if (mins < 1) return 'just now';
+                              if (mins < 60) return `${mins}m ago`;
+                              const hrs = Math.floor(mins / 60);
+                              if (hrs < 24) return `${hrs}h ago`;
+                              return `${Math.floor(hrs / 24)}d ago`;
+                            })()}</>
+                          )}
+                          {s.ipAddress && <> &middot; {s.ipAddress}</>}
                         </p>
                       </div>
                       <button
-                        onClick={() => revokeSessionMutation.mutate(s._id)}
-                        disabled={revokeSessionMutation.isPending}
-                        title="Revoke session"
-                        style={{ background: 'none', border: 'none', cursor: 'pointer', color: '#dc2626', padding: 4, display: 'flex', alignItems: 'center', borderRadius: 6 }}
+                        onClick={() => !s.isCurrent && revokeSessionMutation.mutate(s._id)}
+                        disabled={s.isCurrent || revokeSessionMutation.isPending}
+                        title={s.isCurrent ? 'Cannot remove your current session' : 'Revoke session'}
+                        style={{ background: 'none', border: 'none', cursor: s.isCurrent ? 'not-allowed' : 'pointer', color: s.isCurrent ? '#d1d5db' : '#dc2626', padding: 4, display: 'flex', alignItems: 'center', borderRadius: 6, flexShrink: 0 }}
                       >
                         <Trash2 size={14} />
                       </button>

--- a/web/src/pages/Profile.jsx
+++ b/web/src/pages/Profile.jsx
@@ -1191,7 +1191,7 @@ export default function Profile() {
                               return `${Math.floor(hrs / 24)}d ago`;
                             })()}</>
                           )}
-                          {s.ipAddress && <> &middot; {s.ipAddress}</>}
+                          {s.ipLocation && <> &middot; {s.ipLocation}</>}
                         </p>
                       </div>
                       <button


### PR DESCRIPTION
## Summary
- **Device labels**: `parseDeviceLabel` now extracts browser + major version and OS + version from User-Agent (e.g. \`Chrome 120 on macOS 10.15.7\`, \`Safari 17 on iPhone (iOS 17)\`) and stores client IP in \`RefreshToken.ipAddress\`
- **Immediate session revocation**: \`DELETE /auth/sessions/:id\` now writes a Redis blocklist key (\`revoked_session:{id}\`, TTL 1 day); auth middleware checks it so any in-flight JWT for that session is rejected instantly, not after the 1-day access token expiry — fixes the iOS/Safari bug
- **Current session indicator**: \`sessionId\` (the RefreshToken \`_id\`) is now embedded in every JWT; \`GET /auth/sessions\` marks the current session with \`isCurrent: true\`; Profile Security tab shows a "This device" badge and disables the revoke button for the current session
- **Last active**: \`RefreshToken.lastUsedAt\` is updated on each refresh and surfaced in the sessions list as a relate "Last active" time

## Test plan
- [ ] `cd backend && npm test` — 222 tests pass
- [ ] Log in on two browsers → both appear with distinct versioned labels and different isCurrent values
- [ ] From browser A, revoke browser B's session → browser B's next request returns 401 and redirects to login immediately (no waiting for token expiry)
- [ ] Current session shows "This device" badge; revoke button grayed out for it
- [ ] GET /api-docs → GET /auth/sessions schema shows \`isCurrent\`, \`lastUsedAt\`, \`ipAddress\`