### PR TITLE
fix(observability): proxy PostHog through /ingest to bypass ad blockers

### DIFF
--- a/web/src/lib/posthog.js
+++ b/web/src/lib/posthog.js
@@ -2,7 +2,8 @@ import posthog from 'posthog-js'
 
 if (import.meta.env.VITE_POSTHOG_KEY) {
   posthog.init(import.meta.env.VITE_POSTHOG_KEY, {
-    api_host: import.meta.env.VITE_POSTHOG_HOST || 'https://us.i.posthog.com',
+    api_host: '/ingest',
+    ui_host: 'https://us.posthog.com',
     person_profiles: 'identified_only',
     capture_pageview: true,
     capture_pageleave: true,

--- a/web/vercel.json
+++ b/web/vercel.json
@@ -1,3 +1,13 @@
 {
-  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
+  "rewrites": [
+    {
+      "source": "/ingest/static/:path*",
+      "destination": "https://us-assets.i.posthog.com/static/:path*"
+    },
+    {
+      "source": "/ingest/:path*",
+      "destination": "https://us.i.posthog.com/:path*"
+    },
+    { "source": "/(.*)", "destination": "/index.html" }
+  ]
 }


### PR DESCRIPTION
## Summary

- Routes PostHog requests through `/ingest` on the Vercel domain instead of directly to `us.i.posthog.com`
- Ad blockers reliably block the direct PostHog domain; requests to your own domain pass through unblocked
- This is PostHog's official recommended approach for reliable event capture

## Changes

- `web/vercel.json` — added two rewrites: `/ingest/static/:path*` and `/ingest/:path*` proxying to PostHog's US servers, placed before the SPA catch-all rewrite
- `web/src/lib/posthog.js` — changed `api_host` from `VITE_POSTHOG_HOST` to `/ingest`, added `ui_host: 'https://us.posthog.com'`

## Test plan

- [ ] Deploy to Vercel and confirm `/ingest` rewrites are active
- [ ] Sign in with ad blocker enabled — verify `user_logged_in` event appears in PostHog Live Events
- [ ] Sign in without ad blocker — verify same result

🤖 Generated with [Claude Code](https://claude.com/claude-code)