### PR TITLE
fix(observability): replace rewrite proxy with edge function for PostHog

### DIFF
--- a/web/api/ingest/[...path].js
+++ b/web/api/ingest/[...path].js
@@ -1,0 +1,15 @@
+export const config = { runtime: 'edge' }
+
+export default async function handler(req) {
+  const url = new URL(req.url)
+  const path = url.pathname.replace(/^\/api\/ingest/, '')
+  const host = path.startsWith('/static/')
+    ? 'us-assets.i.posthog.com'
+    : 'us.i.posthog.com'
+
+  return fetch(`https://${host}${path}${url.search}`, {
+    method: req.method,
+    headers: req.headers,
+    body: req.body,
+  })
+}

--- a/web/index.html
+++ b/web/index.html
@@ -9,7 +9,7 @@
 
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="referrer" content="strict-origin-when-cross-origin" />
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://apis.google.com; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data: blob: https://res.cloudinary.com https://*.googleusercontent.com; connect-src 'self' http://localhost:5000 ws://localhost:5000 http://localhost:5001 ws://localhost:5001 https: wss:; frame-src https://docs.google.com https://accounts.google.com; frame-ancestors 'none';" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://apis.google.com; worker-src blob:; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data: blob: https://res.cloudinary.com https://*.googleusercontent.com; connect-src 'self' http://localhost:5000 ws://localhost:5000 http://localhost:5001 ws://localhost:5001 https: wss:; frame-src https://docs.google.com https://accounts.google.com;" />
 
     <!-- Base SEO (overridden per-page by TitleManager) -->
     <title>Continuum | The Student Workspace</title>

--- a/web/vercel.json
+++ b/web/vercel.json
@@ -1,12 +1,8 @@
 {
   "rewrites": [
     {
-      "source": "/ingest/static/:path*",
-      "destination": "https://us-assets.i.posthog.com/static/:path*"
-    },
-    {
       "source": "/ingest/:path*",
-      "destination": "https://us.i.posthog.com/:path*"
+      "destination": "/api/ingest/:path*"
     },
     { "source": "/(.*)", "destination": "/index.html" }
   ]


### PR DESCRIPTION
## Summary

- Fixes 405 errors on all PostHog POST requests (`/ingest/e/`, `/ingest/flags/`, `/ingest/i/v0/e/`)
- Fixes CSP blocking PostHog session recorder worker
- Removes no-op `frame-ancestors` from meta CSP tag

## Root causes

**405 Method Not Allowed:** Vercel `vercel.json` rewrites to external origins do not forward POST request bodies — this is a documented Vercel limitation. Events, flags, and web vitals all use POST and were being silently dropped.

**CSP blob worker blocked:** PostHog's session recorder spawns a `Web Worker` from a `blob:` URL for canvas recording. With no `worker-src` directive, the browser falls back to `script-src` which doesn't include `blob:`. Added `worker-src blob:` to unblock it.

## Changes

- `web/api/ingest/[...path].js` — Vercel edge function that proxies all PostHog requests including POST bodies; routes `/static/*` to `us-assets.i.posthog.com`, everything else to `us.i.posthog.com`
- `web/vercel.json` — simplified to one rewrite: `/ingest/:path*` → `/api/ingest/:path*` (edge function)
- `web/index.html` — added `worker-src blob:` to CSP; removed `frame-ancestors 'none'` (ignored in meta tags, only works via HTTP headers)

## Test plan

- [ ] Deploy and verify `/ingest/e/` returns 200 in Network tab
- [ ] Confirm PostHog Live Events shows events after sign-in
- [ ] Confirm no CSP errors in console for blob worker

🤖 Generated with [Claude Code](https://claude.com/claude-code)