### PR TITLE
fix(observability): rename posthog proxy path from /ingest to /ph

### DIFF
--- a/web/api/ph/[...path].js
+++ b/web/api/ph/[...path].js
@@ -2,7 +2,7 @@ export const config = { runtime: 'edge' }
 
 export default async function handler(req) {
   const url = new URL(req.url)
-  const path = url.pathname.replace(/^\/api\/ingest/, '')
+  const path = url.pathname.replace(/^\/api\/ph/, '')
   const host = path.startsWith('/static/')
     ? 'us-assets.i.posthog.com'
     : 'us.i.posthog.com'

--- a/web/src/lib/posthog.js
+++ b/web/src/lib/posthog.js
@@ -2,7 +2,7 @@ import posthog from 'posthog-js'
 
 if (import.meta.env.VITE_POSTHOG_KEY) {
   posthog.init(import.meta.env.VITE_POSTHOG_KEY, {
-    api_host: '/ingest',
+    api_host: '/ph',
     ui_host: 'https://us.posthog.com',
     person_profiles: 'identified_only',
     capture_pageview: true,

--- a/web/vercel.json
+++ b/web/vercel.json
@@ -1,8 +1,8 @@
 {
   "rewrites": [
     {
-      "source": "/ingest/:path*",
-      "destination": "/api/ingest/:path*"
+      "source": "/ph/:path*",
+      "destination": "/api/ph/:path*"
     },
     { "source": "/(.*)", "destination": "/index.html" }
   ]


### PR DESCRIPTION
## Summary
- Renamed proxy path from `/ingest` to `/ph` across all three touch points
- `/ingest` is in EasyPrivacy's filter list, causing `ERR_BLOCKED_BY_CLIENT` before requests ever reach the edge function
- Renamed edge function directory: `api/ingest/` → `api/ph/`
- Updated `vercel.json` rewrite: `/ingest/:path*` → `/ph/:path*`
- Updated PostHog SDK `api_host`: `'/ingest'` → `'/ph'`
- Request flow unchanged: `browser → /ph/* → edge fn → us.i.posthog.com`