### PR TITLE
fix(auth): fix 500 on send-verification and stale settings display

### DIFF
--- a/backend/controllers/auth.controller.js
+++ b/backend/controllers/auth.controller.js
@@ -748,26 +748,34 @@ exports.sendVerificationEmail = async (req, res) => {
         return res.status(400).json({ success: false, error: 'Email is already verified' });
     }
 
-    const rawToken = req.user.createEmailVerificationToken();
-    // Write token fields directly — avoids validator issues on select:false password field
+    // req.user may be a plain object deserialized from Redis cache (not a Mongoose doc),
+    // so we can't call req.user.createEmailVerificationToken(). Inline the same logic.
+    const rawToken = crypto.randomBytes(32).toString('hex');
+    const hashedToken = crypto.createHash('sha256').update(rawToken).digest('hex');
+    const tokenExpires = Date.now() + 24 * 60 * 60 * 1000;
+
     await User.findByIdAndUpdate(req.user._id, {
-        emailVerificationToken: req.user.emailVerificationToken,
-        emailVerificationExpires: req.user.emailVerificationExpires,
+        emailVerificationToken: hashedToken,
+        emailVerificationExpires: tokenExpires,
     });
 
     const verifyUrl = `${process.env.FRONTEND_URL}/auth/verify-email?token=${rawToken}`;
 
-    await resend.emails.send({
-        from: 'Continuum <noreply@usecontinuum.dev>',
-        to: req.user.email,
-        subject: 'Verify your Continuum email',
-        html: emailTemplate(`
+    try {
+        await resend.emails.send({
+            from: 'Continuum <noreply@usecontinuum.dev>',
+            to: req.user.email,
+            subject: 'Verify your Continuum email',
+            html: emailTemplate(`
             <p style="color:#111827;font-size:16px;margin:0 0 12px;">Hi ${req.user.firstName},</p>
             <p style="color:#374151;font-size:15px;margin:0 0 24px;">Click the button below to verify your email address. This link expires in 24 hours.</p>
             <a href="${verifyUrl}" style="display:inline-block;background:#6B21A8;color:#ffffff;text-decoration:none;padding:12px 24px;border-radius:8px;font-size:15px;font-weight:600;">Verify Email</a>
             <p style="color:#6B7280;font-size:13px;margin:24px 0 0;">If you didn't request this, you can safely ignore this email.</p>
         `),
-    });
+        });
+    } catch (emailErr) {
+        return res.status(500).json({ success: false, error: 'Failed to send verification email. Please try again.' });
+    }
 
     res.status(200).json({ success: true, message: 'Verification email sent' });
 };

--- a/web/src/pages/Profile.jsx
+++ b/web/src/pages/Profile.jsx
@@ -425,11 +425,12 @@ export default function Profile() {
 
   useEffect(() => { setNewPasswordValue(newPwdWatch); }, [newPwdWatch]);
 
-  // Sync profile + notif forms when fresh /me data loads
+  // Sync profile + notif forms when fresh /me data loads, and keep AuthContext in sync
   useEffect(() => {
     if (data) {
       const fresh = data.user || data.data;
       if (!fresh) return;
+      updateUser(fresh);
       resetProfile({
         firstName: fresh.firstName || '',
         lastName: fresh.lastName || '',
@@ -468,7 +469,10 @@ export default function Profile() {
     mutationFn: ({ username }) => api.patch('/auth/me/username', { username }),
     onSuccess: (res) => {
       const updated = res.data.user || res.data.data;
-      if (updated) updateUser(updated);
+      if (updated) {
+        updateUser(updated);
+        queryClient.setQueryData(['me'], (old) => old ? { ...old, user: updated } : old);
+      }
       toast({ type: 'success', message: 'Username updated' });
     },
     onError: (err) => {
@@ -491,7 +495,10 @@ export default function Profile() {
     },
     onSuccess: (res) => {
       const updated = res.data.user || res.data.data;
-      if (updated) updateUser(updated);
+      if (updated) {
+        updateUser(updated);
+        queryClient.setQueryData(['me'], (old) => old ? { ...old, user: updated } : old);
+      }
       setNotifSaved(true);
       setTimeout(() => setNotifSaved(false), 2000);
     },
@@ -506,7 +513,10 @@ export default function Profile() {
     },
     onSuccess: (res) => {
       const updated = res.data.user || res.data.data;
-      if (updated) updateUser(updated);
+      if (updated) {
+        updateUser(updated);
+        queryClient.setQueryData(['me'], (old) => old ? { ...old, user: updated } : old);
+      }
       toast({ type: 'success', message: 'Avatar updated' });
     },
   });

--- a/web/src/pages/auth/EmailVerified.jsx
+++ b/web/src/pages/auth/EmailVerified.jsx
@@ -9,7 +9,7 @@ import { posthog } from '@/lib/posthog';
 export default function EmailVerified() {
   const [searchParams] = useSearchParams();
   const token = searchParams.get('token');
-  const { user } = useAuth();
+  const { user, updateUser } = useAuth();
 
   const [status, setStatus] = useState('loading'); // 'loading' | 'success' | 'error'
   const [errorMsg, setErrorMsg] = useState('');
@@ -30,8 +30,14 @@ export default function EmailVerified() {
 
     api.get(`/auth/verify-email?token=${token}`)
       .then(() => {
-        // Invalidate the cached user so emailVerified: true is reflected immediately
-        queryClient.invalidateQueries({ queryKey: ['me'] });
+        updateUser({ emailVerified: true });
+        queryClient.setQueryData(['me'], (old) => {
+          if (!old) return old;
+          const user = old.user || old.data;
+          if (!user) return old;
+          const updated = { ...user, emailVerified: true };
+          return old.user ? { ...old, user: updated } : { ...old, data: updated };
+        });
         posthog.capture('email_verified', { platform: 'web' });
         setStatus('success');
       })


### PR DESCRIPTION
## Summary

- **500 on send-verification**: `req.user` is deserialized from Redis cache as a plain object — calling `req.user.createEmailVerificationToken()` threw `TypeError: is not a function` because Mongoose methods aren't preserved through JSON serialization. Fixed by inlining the token generation with `crypto` directly (same pattern `verifyEmail` already uses). Also wrapped the Resend call in try/catch so a transient email API failure returns a clean error instead of crashing.
- **Stale settings display**: `avatarMutation`, `usernameMutation`, and `notifMutation` called `updateUser` but not `queryClient.setQueryData`. On next mount, the `['me']` cache (old data) took priority over the updated AuthContext value in `me = data?.user || data?.data || user`. Fixed by adding `setQueryData` to all three mutations, matching what `profileMutation` already did.
- **Email verification badge**: `EmailVerified.jsx` now calls `updateUser` and writes directly to the `['me']` cache on success — the unverified banner disappears instantly without a reload.
- **AuthContext sync**: The Profile data-sync effect now calls `updateUser(fresh)` whenever the `['me']` query returns new data, keeping AuthContext always in sync with the server.

## Test plan

- [ ] Send a verification email — should return 200 (no 500), even when the user has been active long enough for the Redis cache to be populated
- [ ] Click the verification link — profile should show "Verified" immediately on return, no reload needed
- [ ] Update profile fields (name, bio, avatar, username, notifications) — changes should be reflected instantly across all settings tabs without a reload
- [ ] Verify the unverified email banner disappears after clicking the link without needing to navigate away and back

🤖 Generated with [Claude Code](https://claude.com/claude-code)