### PR TITLE
fix: handle 413 payload too large errors for long notes and AI features

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -38,8 +38,8 @@ app.use(cors({
 }));
 
 app.use(cookieParser());
-app.use(bodyParser.json({ limit: '200kb' }));
-app.use(bodyParser.urlencoded({ extended: true, limit: '200kb' }));
+app.use(bodyParser.json({ limit: '1mb' }));
+app.use(bodyParser.urlencoded({ extended: true, limit: '1mb' }));
 
 app.use((req, res, next) => {
   req.body = mongoSanitize(req.body);
@@ -91,7 +91,13 @@ app.use((err, req, res, next) => {
     const messages = Object.values(err.errors).map(e => e.message);
     return res.status(400).json({ success: false, error: messages.join(', ') });
   }
-  const message = process.env.NODE_ENV === 'production' ? 'Internal server error' : err.message;
+  if (err.status === 413 || err.type === 'entity.too.large') {
+    return res.status(413).json({ success: false, error: 'Your note is too large to save. Try shortening the content.' });
+  }
+  const message =
+    process.env.NODE_ENV === 'production' && !err.status
+      ? 'Internal server error'
+      : err.message;
   if (process.env.NODE_ENV !== 'test') {
     logger.error({ err, url: req.url, method: req.method }, 'Unhandled error');
   }

--- a/web/src/components/layout/AppLayout.jsx
+++ b/web/src/components/layout/AppLayout.jsx
@@ -22,6 +22,16 @@ export default function AppLayout() {
     return () => window.removeEventListener('api:ratelimit', handler);
   }, [toast]);
 
+  useEffect(() => {
+    const handler = () => toast({
+      message: "That note is too large — try shortening the content and saving again.",
+      type: 'error',
+      duration: 6000,
+    });
+    window.addEventListener('api:toolarge', handler);
+    return () => window.removeEventListener('api:toolarge', handler);
+  }, [toast]);
+
   if (isLoading) {
     return (
       <div className="flex h-screen items-center justify-center bg-background">

--- a/web/src/lib/api.js
+++ b/web/src/lib/api.js
@@ -39,6 +39,11 @@ api.interceptors.response.use(
     const url = err.config?.url || '';
     const isAuthEndpoint = AUTH_ENDPOINTS.some((path) => url.includes(path));
 
+    if (err.response?.status === 413) {
+      window.dispatchEvent(new CustomEvent('api:toolarge'));
+      return Promise.reject(err);
+    }
+
     if (err.response?.status === 429) {
       if (!rateLimitFired) {
         rateLimitFired = true;

--- a/web/src/pages/notes/NoteEditor.jsx
+++ b/web/src/pages/notes/NoteEditor.jsx
@@ -10,6 +10,7 @@ import queryClient from '@/lib/queryClient';
 import { Card } from '@/components/ui/Card';
 import Button from '@/components/ui/Button';
 import NoteToolbar from './NoteToolbar';
+import { useToast } from '@/components/ui/Toast';
 
 const NOTE_TYPES = ['general', 'lecture', 'research', 'todo', 'journal'];
 
@@ -18,6 +19,7 @@ export default function NoteEditor() {
   const id = state?.id;
   const navigate = useNavigate();
   const isEdit = Boolean(id);
+  const toast = useToast();
 
   const [form, setForm] = useState({
     title: '',
@@ -96,6 +98,11 @@ export default function NoteEditor() {
       // Background invalidation for eventual consistency
       queryClient.invalidateQueries({ queryKey: ['notes'] });
       navigate(noteId ? '/notes/view' : '/notes', noteId ? { state: { id: noteId } } : undefined);
+    },
+    onError: (err) => {
+      if (err.response?.status !== 413) {
+        toast({ message: err.response?.data?.error || 'Failed to save note. Please try again.', type: 'error' });
+      }
     },
   });
 


### PR DESCRIPTION
## Summary
- Raised Express body-parser limit from 200KB to 1MB so notes up to the 200K-char schema cap can be saved
- Added explicit 413 handler in the global error middleware returning a clear message instead of "Internal server error"
- Surfaced intentional Groq errors (rate limits, parse failures) in production instead of hiding them behind the generic fallback
- Added 413 interceptor in the API client that fires a toast notification via `api:toolarge` custom event
- Added `api:toolarge` listener in AppLayout to show user-facing toast
- Added `onError` callback to the NoteEditor save mutation — previously failed silently with no feedback