### PR TITLE
fix(observability): fix posthog edge function proxy routing and headers

### DIFF
--- a/web/api/ph/[...path].js
+++ b/web/api/ph/[...path].js
@@ -3,13 +3,18 @@ export const config = { runtime: 'edge' }
 export default async function handler(req) {
   const url = new URL(req.url)
   const path = url.pathname.replace(/^\/api\/ph/, '')
-  const host = path.startsWith('/static/')
+  const host = (path.startsWith('/static/') || path.startsWith('/array/'))
     ? 'us-assets.i.posthog.com'
     : 'us.i.posthog.com'
 
+  const headers = new Headers(req.headers)
+  headers.delete('host')
+
+  const body = (req.method === 'GET' || req.method === 'HEAD') ? undefined : req.body
+
   return fetch(`https://${host}${path}${url.search}`, {
     method: req.method,
-    headers: req.headers,
-    body: req.body,
+    headers,
+    body,
   })
 }


### PR DESCRIPTION
## Summary
- Route `/array/` paths to `us-assets.i.posthog.com` — was falling through to `us.i.posthog.com` which doesn't serve that path, returning HTML instead of JS and causing `SyntaxError: Unexpected token '<'` (Sentry CONTINUUM-FRONTEND-6)
- Strip `host` header before forwarding requests — verbatim forwarding of `host: usecontinuum.dev` caused PostHog servers to reject with 405
- Omit body for GET/HEAD requests — passing `req.body` stream for non-body methods causes edge runtime errors

These three issues broke PostHog initialization entirely, which prevented `identify()` events from reaching PostHog and caused persons to appear as anonymous UUIDs instead of emails.