### PR TITLE
docs: add observability docs for PostHog events and proxy architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,3 +152,5 @@ Jest + Supertest integration suite covering auth, notes, tasks, flashcards, appl
 | [docs/android/react-to-android.md](docs/android/react-to-android.md) | How the React web app was ported to native Kotlin |
 | [docs/android/api-coverage.md](docs/android/api-coverage.md) | Android endpoint-by-endpoint API coverage matrix |
 | [docs/future-ideas/demo-video-script.md](docs/future-ideas/demo-video-script.md) | Scene-by-scene Android demo recording script |
+| [docs/observability/events.md](docs/observability/events.md) | PostHog events catalog — all custom events, properties, and activation funnel |
+| [docs/observability/architecture.md](docs/observability/architecture.md) | Observability architecture — PostHog proxy, Sentry, identity model, how to test |

--- a/docs/observability/architecture.md
+++ b/docs/observability/architecture.md
@@ -1,0 +1,133 @@
+# Observability Architecture
+
+How monitoring, analytics, and error tracking are wired up in Continuum.
+
+---
+
+## Stack
+
+| Tool | Purpose |
+|------|---------|
+| **PostHog** | Product analytics — events, funnels, person profiles, session replay |
+| **Sentry** | Error tracking — frontend JS exceptions, unhandled promise rejections |
+| **Vercel Analytics** | Web vitals and page performance (built into Vercel deployment) |
+
+---
+
+## PostHog Proxy
+
+PostHog events are routed through a Vercel Edge Function to bypass ad blockers. Without a proxy, requests to `us.i.posthog.com` are blocked by uBlock Origin, EasyPrivacy, and Brave Shields before they leave the browser.
+
+### Request flow
+
+```
+Browser
+  → POST usecontinuum.dev/ph/e/          (ad blockers see your domain, not PostHog)
+  → Vercel rewrite: /ph/* → /api/ph/*
+  → Edge function: web/api/ph/[...path].js
+  → us.i.posthog.com  or  us-assets.i.posthog.com
+```
+
+### Host routing in the edge function
+
+| Path prefix | Upstream host |
+|-------------|--------------|
+| `/static/*` | `us-assets.i.posthog.com` |
+| `/array/*`  | `us-assets.i.posthog.com` |
+| everything else | `us.i.posthog.com` |
+
+`/array/` hosts PostHog's runtime config JS. `/static/` hosts the session recorder and other SDK assets. Both must hit the assets CDN, not the ingestion API.
+
+### Key files
+
+| File | Role |
+|------|------|
+| `web/api/ph/[...path].js` | Vercel Edge Function — proxies all PostHog traffic |
+| `web/vercel.json` | Rewrite rule: `/ph/:path*` → `/api/ph/:path*` |
+| `web/src/lib/posthog.js` | PostHog SDK init with `api_host: '/ph'` |
+| `backend/lib/posthog.js` | `posthog-node` client for server-side event capture |
+
+---
+
+## Identity Model
+
+PostHog uses a **MongoDB `_id`** (ObjectID string) as the `distinctId` for all events — both frontend and backend. This keeps them consistent.
+
+```
+Frontend:  posthog.identify(user._id, { email, username, name, created_at })
+Backend:   posthog.capture({ distinctId: req.user._id.toString(), event, properties })
+```
+
+On first load, PostHog assigns an anonymous UUID. When `identify()` fires (on login, register, or page hydration with a stored token), PostHog merges the anonymous UUID into the `_id` person profile and attaches the email as a display property.
+
+`posthog.reset()` is called on logout to clear the local anonymous ID.
+
+---
+
+## Sentry
+
+Sentry is initialized in the React app and captures all unhandled JS errors and promise rejections in production.
+
+Environment: `production`  
+SDK: `@sentry/react`  
+DSN: set via `VITE_SENTRY_DSN` environment variable
+
+Errors are visible at: [sentry.io](https://sentry.io) → project **CONTINUUM-FRONTEND**
+
+---
+
+## How to Test Events End-to-End
+
+### Prerequisites
+
+- Use **Chrome Incognito with no extensions** — extensions (uBlock, AdBlock) will block requests even through the proxy if they're active in incognito
+- The PR containing proxy fixes must be deployed to Vercel before testing
+
+### Step 1 — Verify the proxy is working
+
+1. Open `https://usecontinuum.dev` in incognito (no extensions)
+2. Open DevTools → Network tab → filter by `ph/`
+3. All requests should return `200` — no `405`, no `ERR_BLOCKED_BY_CLIENT`
+4. You should see: `ph/array/.../config.js`, `ph/flags/`, `ph/e/`
+
+### Step 2 — Fire each event
+
+Work through these in order in the same incognito session:
+
+| # | Action | Expected event |
+|---|--------|----------------|
+| 1 | Register a new account | `user_registered` |
+| 2 | Create a note manually | `note_created` |
+| 3 | Generate flashcards from that note | `flashcard_set_generated` |
+| 4 | Generate a summary on the note | `note_summary_generated` |
+| 5 | Open a flashcard set and flip through 5+ cards | `study_session_started` |
+| 6 | Finish the study session | `study_session_completed` |
+| 7 | Upload a resume | `resume_uploaded` |
+| 8 | Run AI feedback on the resume | `resume_feedback_generated` |
+| 9 | Create a job application | `job_application_created` |
+| 10 | Create a task | `task_created` |
+| 11 | Send a friend request | `friend_request_sent` |
+| 12 | Send a direct message | `message_sent` |
+| 13 | Leave a comment on a note | `comment_added` |
+
+### Step 3 — Confirm in PostHog
+
+Go to **PostHog → Activity → Live Events**. Events should appear within 2–5 seconds of each action. The person should show as the registered user's email (after `identify` fires on registration).
+
+### Step 4 — Verify the activation funnel
+
+Go to **PostHog → Dashboards → Launch → Activation Funnel**. After completing steps 1–9 above, both steps of the funnel should show conversion.
+
+---
+
+## Clean Slate Before Launch
+
+Before your product launch, wipe all test data:
+
+**MongoDB Atlas:**  
+Drop all collections or use the Atlas UI to delete and recreate the database. This removes all test users, notes, flashcard sets, etc.
+
+**PostHog:**  
+Settings → Project → Reset project data. This wipes all persons and events while preserving your project key, funnel configuration, and dashboard setup.
+
+Do this only after confirming the proxy works end-to-end so the first real user data that enters PostHog is clean.

--- a/docs/observability/events.md
+++ b/docs/observability/events.md
@@ -1,0 +1,116 @@
+# PostHog Events Catalog
+
+All custom events tracked in Continuum. Every event is either fired from the **frontend** (React web, `posthog-js`) or the **backend** (Node.js, `posthog-node`).
+
+---
+
+## Identity
+
+Before any custom events fire, the frontend calls `posthog.identify()` to link the PostHog person to the logged-in user.
+
+| Call | distinctId | Properties |
+|------|-----------|------------|
+| `posthog.identify()` | MongoDB `_id` | `email`, `username`, `name`, `created_at` |
+
+Called on: email login, email registration, Google OAuth callback, and page hydration (if a stored token exists).  
+`posthog.reset()` is called on logout to clear the local identity.
+
+---
+
+## Auth Events
+
+| Event | Source | Fired When | Key Properties |
+|-------|--------|-----------|----------------|
+| `user_registered` | frontend | Successful email/password registration | `platform: 'web'`, `method: 'email'` |
+| `user_logged_in` | frontend | Successful login (email or Google OAuth) | `platform: 'web'`, `method: 'email' \| 'google'` |
+| `user_logged_out` | frontend | User clicks logout | `platform: 'web'` |
+
+---
+
+## Notes Events
+
+| Event | Source | Fired When | Key Properties |
+|-------|--------|-----------|----------------|
+| `note_created` | backend | A new note is saved | `noteId`, `userId` |
+| `note_summary_generated` | backend | AI summary is generated for a note | `noteId`, `userId` |
+
+---
+
+## Flashcards Events
+
+| Event | Source | Fired When | Key Properties |
+|-------|--------|-----------|----------------|
+| `flashcard_set_generated` | backend | AI generates a flashcard set from a note or PDF | `flashcardSetId`, `userId`, `cardCount` |
+
+---
+
+## Study Events
+
+| Event | Source | Fired When | Key Properties |
+|-------|--------|-----------|----------------|
+| `study_session_started` | backend | User begins a study session on a flashcard set | `sessionId`, `flashcardSetId`, `userId` |
+| `study_session_completed` | backend | User finishes a study session | `sessionId`, `flashcardSetId`, `userId`, `cardsStudied`, `score` |
+
+---
+
+## Resume Events
+
+| Event | Source | Fired When | Key Properties |
+|-------|--------|-----------|----------------|
+| `resume_uploaded` | backend | User uploads a PDF resume to Cloudinary | `resumeId`, `userId` |
+| `resume_feedback_generated` | backend | AI runs section-by-section resume analysis | `resumeId`, `userId` |
+
+---
+
+## Career Events
+
+| Event | Source | Fired When | Key Properties |
+|-------|--------|-----------|----------------|
+| `job_application_created` | backend | User creates a new job application entry | `applicationId`, `userId` |
+
+---
+
+## Task Events
+
+| Event | Source | Fired When | Key Properties |
+|-------|--------|-----------|----------------|
+| `task_created` | backend | User creates a new task | `taskId`, `userId` |
+
+---
+
+## Social Events
+
+| Event | Source | Fired When | Key Properties |
+|-------|--------|-----------|----------------|
+| `friend_request_sent` | backend | User sends a friend request | `fromUserId`, `toUserId` |
+| `message_sent` | backend | User sends a direct message | `conversationId`, `userId` |
+| `comment_added` | backend | User leaves a comment on a note | `commentId`, `targetId`, `targetType`, `userId` |
+
+---
+
+## Autocapture Events (PostHog built-in)
+
+These fire automatically — no code required.
+
+| Event | Description |
+|-------|-------------|
+| `$pageview` | Every page navigation |
+| `$pageleave` | User leaves a page |
+| `$autocapture` | Clicks, form interactions, and other DOM events |
+| `$identify` | Identity merge when `posthog.identify()` fires |
+| `$set` | Person property update |
+
+---
+
+## Activation Funnel
+
+The core activation funnel in PostHog (saved as **Activation Funnel** on the **Launch** dashboard):
+
+```
+user_registered
+  → flashcard_set_generated OR note_summary_generated OR resume_feedback_generated
+```
+
+Conversion window: 7 days, Sequential order.
+
+This measures whether a new user reaches a meaningful "aha moment" — generating AI-powered content — within their first week.


### PR DESCRIPTION
## Summary
- `docs/observability/events.md` — full PostHog events catalog: all 15 custom events with source (frontend/backend), trigger condition, and key properties; identity model; activation funnel definition
- `docs/observability/architecture.md` — PostHog proxy architecture, host routing logic, Sentry setup, identity flow, and a step-by-step end-to-end testing guide (including clean slate instructions before launch)
- Root `README.md` — linked both new docs in the Documentation table