### PR TITLE
fix(observability): fix posthog edge function path stripping regex

### DIFF
--- a/web/api/ph/[...path].js
+++ b/web/api/ph/[...path].js
@@ -2,7 +2,7 @@ export const config = { runtime: 'edge' }
 
 export default async function handler(req) {
   const url = new URL(req.url)
-  const path = url.pathname.replace(/^\/api\/ph/, '')
+  const path = url.pathname.replace(/^\/(?:api\/)?ph/, '')
   const host = (path.startsWith('/static/') || path.startsWith('/array/'))
     ? 'us-assets.i.posthog.com'
     : 'us.i.posthog.com'


### PR DESCRIPTION
## Summary
- Fixes the root cause of all PostHog proxy errors (405 on `/ph/e/` and `/ph/flags/`, SyntaxError on `config.js`)

## Root cause
Vercel Edge Functions receive the **original browser URL** in `req.url`, not the rewritten destination. The vercel.json rewrite maps `/ph/*` → `/api/ph/*`, but the edge function still sees `/ph/e/` in `req.url`.

The old regex `/^\/api\/ph/` never matched `/ph/e/`, so the path was never stripped and the proxy forwarded to:
- `us.i.posthog.com/ph/e/` → **405**
- `us.i.posthog.com/ph/array/.../config.js` → **HTML 404 → SyntaxError**

## Fix
```js
// Before — never matches because req.url is /ph/e/, not /api/ph/e/
const path = url.pathname.replace(/^\/api\/ph/, '')

// After — handles both /ph/... and /api/ph/... 
const path = url.pathname.replace(/^\/(?:api\/)?ph/, '')
```