### PR TITLE
feat(observability): add note_viewed, flashcard_set_viewed, google_auth_linked events

### DIFF
--- a/backend/controllers/auth.controller.js
+++ b/backend/controllers/auth.controller.js
@@ -457,6 +457,12 @@ exports.googleLink = async (req, res) => {
     req.user.googleTokenExpiry = new Date(Date.now() + 3600 * 1000);
     await req.user.save();
 
+    posthog.capture({
+        distinctId: req.user._id.toString(),
+        event: 'google_auth_linked',
+        properties: {},
+    });
+
     res.status(200).json({ success: true, user: req.user });
 };
 

--- a/docs/observability/events.md
+++ b/docs/observability/events.md
@@ -27,6 +27,7 @@ Called on: email login, email registration, Google OAuth callback, and page hydr
 | `account_deletion_requested` | backend | User soft-deletes their account (30-day grace period starts) | `scheduledDeletionAt` |
 | `account_restored` | backend | User recovers their account before the 30-day window closes | — |
 | `google_auth_linked` | backend | User links a Google account to an existing email/password account | — |
+| `email_verified` | frontend | User successfully verifies their email address | `platform: 'web'` |
 
 ---
 

--- a/docs/observability/events.md
+++ b/docs/observability/events.md
@@ -26,6 +26,7 @@ Called on: email login, email registration, Google OAuth callback, and page hydr
 | `user_logged_out` | frontend | User clicks logout | `platform: 'web'` |
 | `account_deletion_requested` | backend | User soft-deletes their account (30-day grace period starts) | `scheduledDeletionAt` |
 | `account_restored` | backend | User recovers their account before the 30-day window closes | — |
+| `google_auth_linked` | backend | User links a Google account to an existing email/password account | — |
 
 ---
 
@@ -34,6 +35,7 @@ Called on: email login, email registration, Google OAuth callback, and page hydr
 | Event | Source | Fired When | Key Properties |
 |-------|--------|-----------|----------------|
 | `note_created` | backend | A new note is saved | `noteId`, `userId` |
+| `note_viewed` | frontend | User opens a note detail page | `platform: 'web'`, `noteId` |
 | `note_summary_generated` | backend | AI summary is generated for a note | `noteId`, `userId` |
 | `note_deleted` | backend | User soft-deletes a note | `noteId` |
 | `note_shared` | backend | User shares a note — `audience: 'friends'` = all friends, `audience: 'specific'` = named friends | `noteId`, `audience`, `recipientCount` |
@@ -47,6 +49,7 @@ Called on: email login, email registration, Google OAuth callback, and page hydr
 | Event | Source | Fired When | Key Properties |
 |-------|--------|-----------|----------------|
 | `flashcard_set_generated` | backend | AI generates a flashcard set from a note or PDF | `flashcardSetId`, `userId`, `cardCount` |
+| `flashcard_set_viewed` | frontend | User opens a flashcard set detail page | `platform: 'web'`, `setId` |
 | `flashcard_set_deleted` | backend | User deletes a flashcard set | `flashcardSetId` |
 | `flashcard_set_shared` | backend | User shares a flashcard set — `audience: 'friends'` or `audience: 'specific'` | `flashcardSetId`, `audience`, `recipientCount` |
 | `flashcard_set_unshared` | backend | User sets a flashcard set back to private | `flashcardSetId`, `previousAudience` |

--- a/web/src/pages/flashcards/FlashcardSetDetail.jsx
+++ b/web/src/pages/flashcards/FlashcardSetDetail.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useLocation, Link, useNavigate } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { ArrowLeft, Plus, Sparkles, Play, Trash2, Pencil, Share2, Copy, ChevronDown, ChevronUp, CheckCircle, XCircle } from 'lucide-react';
@@ -12,6 +12,7 @@ import Modal from '@/components/ui/Modal';
 import Badge from '@/components/ui/Badge';
 import ShareModal from '@/components/ui/ShareModal';
 import { useAuth } from '@/context/AuthContext';
+import { posthog } from '@/lib/posthog';
 
 export default function FlashcardSetDetail() {
   const { state } = useLocation();
@@ -43,6 +44,12 @@ export default function FlashcardSetDetail() {
     queryFn: () => api.get(`/flashcard-sets/${id}`).then(r => r.data),
     enabled: !!id,
   });
+
+  useEffect(() => {
+    const set = data?.set || data?.data;
+    if (set?._id) posthog.capture('flashcard_set_viewed', { platform: 'web', setId: set._id });
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [data]);
 
   const { data: historyData, isLoading: historyLoading } = useQuery({
     queryKey: ['study-sessions', id],

--- a/web/src/pages/notes/NoteDetail.jsx
+++ b/web/src/pages/notes/NoteDetail.jsx
@@ -18,6 +18,7 @@ import Modal from '@/components/ui/Modal';
 import ShareModal from '@/components/ui/ShareModal';
 import { useAuth } from '@/context/AuthContext';
 import { formatDate } from '@/lib/utils';
+import { posthog } from '@/lib/posthog';
 
 export default function NoteDetail() {
   const { state } = useLocation();
@@ -38,6 +39,12 @@ export default function NoteDetail() {
     queryKey: ['note', id],
     queryFn: () => api.get(`/notes/${id}`).then(r => r.data),
   });
+
+  useEffect(() => {
+    const n = data?.note || data?.data;
+    if (n?._id) posthog.capture('note_viewed', { platform: 'web', noteId: n._id });
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [data]);
 
   // Viewing a note updates lastViewedAt on the backend (affects list sort order).
   // Invalidate the notes list on unmount so the list refetches with the correct order.


### PR DESCRIPTION
## Summary
- `note_viewed` (frontend) — fires in `NoteDetail.jsx` once when note data loads
- `flashcard_set_viewed` (frontend) — fires in `FlashcardSetDetail.jsx` once when set data loads
- `google_auth_linked` (backend) — fires in `auth.controller.js` after a user links Google to an existing email/password account
- `docs/observability/events.md` updated with all three