### PR TITLE
fix: instant UX and polish across registration, messages, and activity

### DIFF
--- a/backend/controllers/activity.controller.js
+++ b/backend/controllers/activity.controller.js
@@ -38,6 +38,7 @@ exports.getActivityFeed = async (req, res) => {
 
     // Base filter — no cursor constraint, used for the total count
     const baseFilter = {
+        userId: { $ne: userId },
         $or: [
             { visibleTo: userId },
             { isPublic: true },

--- a/backend/controllers/auth.controller.js
+++ b/backend/controllers/auth.controller.js
@@ -168,11 +168,10 @@ const resolveLocation = (ip) => {
 exports.register = async (req, res) => {
     const { email, username, password, firstName, lastName } = req.body;
 
-    // Return 409 if email or username is already taken
-    const existing = await User.findOne({ $or: [{ email }, { username }] });
-    if (existing) {
-        return res.status(409).json({ success: false, error: 'Email or username already in use' });
-    }
+    const emailExists = await User.findOne({ email }).select('_id');
+    if (emailExists) return res.status(409).json({ success: false, error: 'Email already registered' });
+    const usernameExists = await User.findOne({ username }).select('_id');
+    if (usernameExists) return res.status(409).json({ success: false, error: 'Username already taken' });
 
     // Create user — pre-save hook in User.js automatically hashes the password
     const user = await User.create({ email, username, password, firstName, lastName });

--- a/backend/controllers/comments.controller.js
+++ b/backend/controllers/comments.controller.js
@@ -128,7 +128,7 @@ exports.addComment = async (req, res) => {
         type: 'comment_added',
         targetId: comment.targetId,
         targetType: comment.targetType,
-        metadata: { commentPreview: content.trim().slice(0, 100) },
+        metadata: { commentPreview: content.trim().slice(0, 100), commentId: comment._id.toString() },
     }).catch(() => {});
 
     // Notify the resource owner (if different from commenter)

--- a/backend/controllers/comments.controller.js
+++ b/backend/controllers/comments.controller.js
@@ -268,6 +268,14 @@ exports.toggleLike = async (req, res) => {
             targetType: 'comment',
             metadata: { commentPreview: comment.content?.slice(0, 100) },
         }).catch(() => {});
+
+        // Notify the comment author instantly so their activity feed updates
+        const commentAuthorId = comment.userId?.toString();
+        if (commentAuthorId && commentAuthorId !== userId.toString()) {
+            try {
+                getIO().to(`user:${commentAuthorId}`).emit('like_added');
+            } catch (_) {}
+        }
     }
 
     res.status(200).json({ success: true, liked: !alreadyLiked, comment: updated });

--- a/backend/controllers/comments.controller.js
+++ b/backend/controllers/comments.controller.js
@@ -266,7 +266,11 @@ exports.toggleLike = async (req, res) => {
             type: 'like_added',
             targetId: comment._id,
             targetType: 'comment',
-            metadata: { commentPreview: comment.content?.slice(0, 100) },
+            metadata: {
+                commentPreview: comment.content?.slice(0, 100),
+                resourceId: comment.targetId?.toString(),
+                resourceType: comment.targetType,
+            },
         }).catch(() => {});
 
         // Notify the comment author instantly so their activity feed updates

--- a/backend/controllers/flashcardSets.controller.js
+++ b/backend/controllers/flashcardSets.controller.js
@@ -189,6 +189,15 @@ exports.deleteSet = async (req, res) => {
         properties: { flashcardSetId: set._id.toString() },
     });
 
+    // Notify shared users so their UI removes the set without a refresh
+    try {
+        const io = getIO();
+        const setId = set._id.toString();
+        set.sharedWith.forEach(uid => {
+            io.to(`user:${uid}`).emit('flashcard_set_deleted', { setId });
+        });
+    } catch (_) {}
+
     res.status(200).json({ success: true, message: 'Flashcard set deleted' });
 };
 

--- a/backend/controllers/notes.controller.js
+++ b/backend/controllers/notes.controller.js
@@ -365,6 +365,15 @@ exports.deleteNote = async (req, res) => {
         properties: { noteId: note._id.toString() },
     });
 
+    // Notify shared users so their UI removes the note without a refresh
+    try {
+        const io = getIO();
+        const noteId = note._id.toString();
+        note.sharedWith.forEach(uid => {
+            io.to(`user:${uid}`).emit('note_deleted', { noteId });
+        });
+    } catch (_) {}
+
     res.status(200).json({ success: true, message: 'Note deleted' });
 };
 

--- a/backend/controllers/tasks.controller.js
+++ b/backend/controllers/tasks.controller.js
@@ -433,6 +433,7 @@ exports.updateParticipantStatus = async (req, res) => {
     participant.completedAt = status === 'completed' ? new Date() : null;
 
     await task.save();
+    emitTaskUpdate(task, req.user._id);
 
     res.status(200).json({ success: true, task });
 };

--- a/backend/controllers/users.controller.js
+++ b/backend/controllers/users.controller.js
@@ -68,7 +68,7 @@ exports.searchUsers = async (req, res) => {
         isSeedUser: { $ne: true },
         $or: [{ username: regex }, { email: regex }],
     })
-        .select('username firstName lastName')
+        .select('username firstName lastName avatarUrl roles')
         .limit(20);
 
     res.status(200).json({ success: true, users });

--- a/backend/scripts/migrate-comment-activity-targettype.js
+++ b/backend/scripts/migrate-comment-activity-targettype.js
@@ -1,0 +1,41 @@
+/**
+ * Migration: fix comment_added activity records that have targetType: 'comment'
+ * and targetId pointing to the comment's own _id.
+ *
+ * Correct shape: targetId = resource _id (note/flashcardSet/task), targetType = resource type.
+ * Broken shape:  targetId = comment._id, targetType = 'comment' (seed bug).
+ *
+ * For each broken record, look up the comment and copy comment.targetId / comment.targetType.
+ */
+
+require('dotenv').config();
+const mongoose = require('mongoose');
+const Activity = require('../models/Activity');
+const Comment  = require('../models/Comment');
+
+async function run() {
+  await mongoose.connect(process.env.MONGO_URI);
+  console.log('Connected');
+
+  const broken = await Activity.find({ type: 'comment_added', targetType: 'comment' });
+  console.log(`Found ${broken.length} broken comment_added activities`);
+
+  let fixed = 0;
+  let skipped = 0;
+
+  for (const act of broken) {
+    const comment = await Comment.findById(act.targetId).select('targetId targetType');
+    if (!comment) { skipped++; continue; }
+
+    await Activity.updateOne(
+      { _id: act._id },
+      { $set: { targetId: comment.targetId, targetType: comment.targetType } }
+    );
+    fixed++;
+  }
+
+  console.log(`Fixed: ${fixed}, Skipped (comment deleted): ${skipped}`);
+  await mongoose.disconnect();
+}
+
+run().catch(e => { console.error(e); process.exit(1); });

--- a/backend/scripts/seed-jane.js
+++ b/backend/scripts/seed-jane.js
@@ -723,10 +723,10 @@ async function seedActivities(jane, friends, sharedNotes, allSets, allTasks, all
     await Activity.create({
       userId: jane._id,
       type: 'comment_added',
-      targetId: comment._id,
-      targetType: 'comment',
+      targetId: comment.targetId,
+      targetType: comment.targetType,
       visibleTo: [jane._id, ...allFriendIds],
-      metadata: { commentPreview: comment.content.slice(0, 100) },
+      metadata: { commentPreview: comment.content.slice(0, 100), commentId: comment._id.toString() },
       createdAt: bumpDate(),
     });
     count++;
@@ -745,10 +745,10 @@ async function seedActivities(jane, friends, sharedNotes, allSets, allTasks, all
     await Activity.create({
       userId: commenterFriend._id,
       type: 'comment_added',
-      targetId: fc._id,
-      targetType: 'comment',
+      targetId: fc.targetId,
+      targetType: fc.targetType,
       visibleTo: visibleToAll,
-      metadata: { commentPreview: fc.content.slice(0, 100) },
+      metadata: { commentPreview: fc.content.slice(0, 100), commentId: fc._id.toString() },
       createdAt: bumpDate(),
     });
     count++;
@@ -1057,6 +1057,13 @@ async function main() {
 
     // 12. Friend content (shared notes, flashcard sets, shared tasks with Jane)
     await seedFriendContent(jane, friends);
+
+    // Bust Redis activity cache so pages don't show stale data after reseed
+    try {
+      const { invalidatePattern } = require('../lib/cache');
+      const allIds = [jane._id, ...friends.map(f => f._id)];
+      for (const uid of allIds) await invalidatePattern(`activity:${uid}:first`);
+    } catch (_) {}
 
     console.log('\nJane Doe demo account seeded successfully!');
     console.log('  Email:    janedoe_demo@example.com');

--- a/backend/scripts/seed-justin.js
+++ b/backend/scripts/seed-justin.js
@@ -1463,10 +1463,10 @@ async function seedActivities(justin, friends, justinNotes, friendNoteMap, justi
     await Activity.create({
       userId: justin._id,
       type: 'comment_added',
-      targetId: comment._id,
-      targetType: 'comment',
+      targetId: comment.targetId,
+      targetType: comment.targetType,
       visibleTo: [justin._id, ...allFriendIds],
-      metadata: { commentPreview: comment.content.slice(0, 100) },
+      metadata: { commentPreview: comment.content.slice(0, 100), commentId: comment._id.toString() },
       createdAt: bumpDate(),
     });
     count++;
@@ -1540,10 +1540,10 @@ async function seedActivities(justin, friends, justinNotes, friendNoteMap, justi
       await Activity.create({
         userId: friend._id,
         type: 'comment_added',
-        targetId: fc._id,
-        targetType: 'comment',
+        targetId: fc.targetId,
+        targetType: fc.targetType,
         visibleTo: visibleToAll,
-        metadata: { commentPreview: fc.content.slice(0, 100) },
+        metadata: { commentPreview: fc.content.slice(0, 100), commentId: fc._id.toString() },
         createdAt: bumpDate(),
       });
       count++;
@@ -1788,6 +1788,14 @@ async function main() {
       'settings.activityVisibility': 'friends',
       roles: ['founder', 'team'],
     });
+
+    // Bust Redis activity cache so dashboard/activity pages don't show stale data
+    try {
+      const { invalidatePattern } = require('../lib/cache');
+      await invalidatePattern(`activity:${justin._id}:first`);
+      const allIds = [...allFriendIds, justin._id];
+      for (const uid of allIds) await invalidatePattern(`activity:${uid}:first`);
+    } catch (_) {}
 
     console.log('\nSeed complete!');
   } catch (err) {

--- a/docs/backend/api_reference_guide.md
+++ b/docs/backend/api_reference_guide.md
@@ -184,7 +184,7 @@ Sharing activities are personalized: the sharer's feed shows who they shared wit
 ### **Resume Management**
 - `POST /api/resumes/upload` - Upload resume PDF with label and target role (multipart/form-data); stored as `type: authenticated` in Cloudinary
 - `GET /api/resumes` - List all resume versions for user. Supports `?search=` for case-insensitive regex match on `fileName`, `version`, and `targetRole`.
-- `GET /api/resumes/:resumeId/download` - Generate a 10-minute signed download URL via `private_download_url`; requires ownership
+- `GET /api/resumes/:resumeId/download` - Generate a download URL (adds `fl_attachment` transform); used by both the Download button and the PDF viewer modal on web
 - `POST /api/resumes/:resumeId/feedback` - Generate AI-powered feedback via Groq (appended to embedded feedback array)
 - `GET /api/resumes/:resumeId/feedback` - Retrieve all feedback entries for a resume
 - `DELETE /api/resumes/:resumeId` - Soft delete resume

--- a/docs/backend/api_reference_guide.md
+++ b/docs/backend/api_reference_guide.md
@@ -11,7 +11,7 @@
 ## Authentication & User Management
 
 ### **Authentication**
-- `POST /api/auth/register` - Create new user account, return JWT + refresh token
+- `POST /api/auth/register` - Create new user account, return JWT + refresh token. Email and username are checked separately — returns 409 `'Email already registered'` or `'Username already taken'` with distinct messages so the UI can surface which field is the problem.
 - `POST /api/auth/login` - Authenticate user, return JWT + refresh token
 - `POST /api/auth/refresh` - Exchange a valid refresh token for a new access token with full token rotation — the old token is immediately revoked and a new httpOnly cookie is issued. Old `sessionId` written to Redis blocklist to reject any still-valid JWT bearing it. Device/location metadata inherited by new token. (public)
 - `POST /api/auth/logout` - Revoke current device's refresh token (protected)

--- a/docs/backend/backend_user_flows.md
+++ b/docs/backend/backend_user_flows.md
@@ -11,7 +11,8 @@ Every critical user journey from the backend perspective. Maps each user action 
 User fills out registration form
   → POST /api/auth/register { email, username, password, firstName, lastName, deviceId? }
   → Server validates: email format, username length, password strength
-  → Server checks: email unique, username unique (409 CONFLICT if not)
+  → Server checks email unique (409 'Email already registered' if not)
+  → Server checks username unique (409 'Username already taken' if not)
   → User.create() → pre-save hook hashes password with bcrypt
   → Sign JWT { userId } — access token (1d)
   → Generate RefreshToken (SHA-256 hash in DB, raw 80-char hex to client, 30d)

--- a/docs/backend/system-design.md
+++ b/docs/backend/system-design.md
@@ -70,7 +70,7 @@ flowchart TB
     CC -- "invalidate keys" --> REDIS_LIB
 
     %% Socket pushes to client
-    IO -- "new_message\nfriend_request\ntask_updated\nnote_shared\nactivity_updated\nflashcard_shared\ncomment_added\nstudy:session-complete" --> SC
+    IO -- "new_message\nfriend_request\ntask_updated\nnote_shared\nnote_deleted\nactivity_updated\nlike_added\nflashcard_shared\nflashcard_set_deleted\ncomment_added\nstudy:session-complete" --> SC
 
     %% Client reacts
     SC -- "invalidateQueries" --> RQ

--- a/docs/continuum-interview-brief.md
+++ b/docs/continuum-interview-brief.md
@@ -61,7 +61,7 @@ Built over 8 weeks for the 2026 All Star Code Technical Entrepreneurship Incubat
 - **Tasks** — kanban board with shared tasks, per-participant status tracking, recurrence support, infinite-scroll pagination
 - **Calendar** — event creation and scheduling integrated with the task system
 - **Social** — friend requests, activity feed (cursor-paginated, own actions filtered Instagram-style, shared content titles and comment previews are clickable purple links with scroll-to-comment on the target page), direct messaging with real-time socket delivery (no polling), profile photos in feed and comments
-- **Career** — job application tracker with status pipeline, AI resume feedback (scored section-by-section), contacts and reminders per application
+- **Career** — job application tracker with status pipeline, AI resume feedback (scored section-by-section), contacts and reminders per application, inline PDF resume viewer (iframe modal matching Android's in-app viewer)
 - **Auth** — email/password and Google OAuth (`drive.file` scope — non-sensitive, no CASA assessment required) with JWT + httpOnly refresh cookie rotation
 - **Dashboard** — accurate total counts pulled from paginated response metadata (not capped list lengths)
 

--- a/docs/continuum-interview-brief.md
+++ b/docs/continuum-interview-brief.md
@@ -60,7 +60,7 @@ Built over 8 weeks for the 2026 All Star Code Technical Entrepreneurship Incubat
 - **Flashcards** — study mode with flip cards, per-card progress tracking, AI extraction from notes or PDFs, study history screen, infinite-scroll pagination
 - **Tasks** — kanban board with shared tasks, per-participant status tracking, recurrence support, infinite-scroll pagination
 - **Calendar** — event creation and scheduling integrated with the task system
-- **Social** — friend requests, activity feed (cursor-paginated), direct messaging with real-time delivery, profile photos in feed and comments
+- **Social** — friend requests, activity feed (cursor-paginated, own actions filtered Instagram-style, shared content titles clickable), direct messaging with real-time socket delivery (no polling), profile photos in feed and comments
 - **Career** — job application tracker with status pipeline, AI resume feedback (scored section-by-section), contacts and reminders per application
 - **Auth** — email/password and Google OAuth (`drive.file` scope — non-sensitive, no CASA assessment required) with JWT + httpOnly refresh cookie rotation
 - **Dashboard** — accurate total counts pulled from paginated response metadata (not capped list lengths)
@@ -873,11 +873,16 @@ Token is passed in `auth`, which maps to `socket.handshake.auth` on the backend.
 | `task_deleted` | `['tasks']`, `['calendar']` |
 | `note_updated` | `['notes']` |
 | `note_shared` | `['notes']` |
+| `note_deleted` | `['notes']` + removes `['note', noteId]` from cache |
 | `comment_added` | `['note', targetId]` or `['flashcard-set', targetId]` or `['tasks']`, + `['activity']` |
+| `like_added` | `['activity']` |
 | `flashcard_shared` | `['flashcard-sets']` |
+| `flashcard_set_deleted` | `['flashcard-sets']` + removes `['flashcard-set', setId]` from cache |
 | `activity_updated` | `['activity']` |
 
 This is the bridge between real-time events and the UI. When a socket event fires, `queryClient.invalidateQueries()` marks the data as stale. React Query automatically refetches the next time the component is visible or focused. The user sees updated data without a page reload, without polling, and without manual state management.
+
+**Socket token refresh:** After the Axios interceptor silently refreshes a JWT, `updateSocketToken(newToken)` updates the socket's `auth` object so any future reconnection uses the new token — preventing a socket that reconnects after a network blip from failing auth with a stale token.
 
 ---
 
@@ -1408,4 +1413,4 @@ Each PR includes:
 
 This creates a paper trail. Six months from now, you can read a PR and understand exactly what problem it solved, what it changed, and how to verify it worked.
 
-*Last updated: April 21, 2026*
+*Last updated: April 24, 2026*

--- a/docs/continuum-interview-brief.md
+++ b/docs/continuum-interview-brief.md
@@ -60,7 +60,7 @@ Built over 8 weeks for the 2026 All Star Code Technical Entrepreneurship Incubat
 - **Flashcards** — study mode with flip cards, per-card progress tracking, AI extraction from notes or PDFs, study history screen, infinite-scroll pagination
 - **Tasks** — kanban board with shared tasks, per-participant status tracking, recurrence support, infinite-scroll pagination
 - **Calendar** — event creation and scheduling integrated with the task system
-- **Social** — friend requests, activity feed (cursor-paginated, own actions filtered Instagram-style, shared content titles clickable), direct messaging with real-time socket delivery (no polling), profile photos in feed and comments
+- **Social** — friend requests, activity feed (cursor-paginated, own actions filtered Instagram-style, shared content titles and comment previews are clickable purple links with scroll-to-comment on the target page), direct messaging with real-time socket delivery (no polling), profile photos in feed and comments
 - **Career** — job application tracker with status pipeline, AI resume feedback (scored section-by-section), contacts and reminders per application
 - **Auth** — email/password and Google OAuth (`drive.file` scope — non-sensitive, no CASA assessment required) with JWT + httpOnly refresh cookie rotation
 - **Dashboard** — accurate total counts pulled from paginated response metadata (not capped list lengths)
@@ -1413,4 +1413,4 @@ Each PR includes:
 
 This creates a paper trail. Six months from now, you can read a PR and understand exactly what problem it solved, what it changed, and how to verify it worked.
 
-*Last updated: April 24, 2026*
+*Last updated: April 24, 2026 (evening)*

--- a/docs/frontend/api_coverage.md
+++ b/docs/frontend/api_coverage.md
@@ -135,7 +135,7 @@ Frontend base URL: `http://localhost:5173`
 | GET | `/api/conversations` | `pages/messages/Messages.jsx` (supports `?search=` by participant name) | List of conversations |
 | POST | `/api/conversations` | `pages/friends/Friends.jsx` → Message button | Body: `{ participantId: friendId }` |
 | DELETE | `/api/conversations/:id` | `pages/messages/Conversation.jsx` header trash icon + `pages/messages/Messages.jsx` hover trash | Instagram-style: hidden for current user only |
-| GET | `/api/conversations/:id/messages` | `pages/messages/Conversation.jsx` (supports `?search=` by content; polling disabled while searching) | Polled every 5s |
+| GET | `/api/conversations/:id/messages` | `pages/messages/Conversation.jsx` (supports `?search=` by content; polling disabled while searching) | Socket-driven (`new_message` event invalidates cache instantly — no polling) |
 | POST | `/api/conversations/:id/messages` | `pages/messages/Conversation.jsx` → send input | Body: `{ content }` |
 | DELETE | `/api/messages/:id` | `pages/messages/Conversation.jsx` hover trash on bubble | Instagram-style: hidden for current user only |
 | PUT | `/api/messages/:id/read` | Auto-mark read on Conversation mount | |

--- a/web/e2e/auth.spec.ts
+++ b/web/e2e/auth.spec.ts
@@ -34,10 +34,9 @@ test.describe('Auth', () => {
     await page.fill('input[name="password"]', user.password);
     await page.click('button:has-text("Create account")');
 
-    // Should stay on register with an error banner visible
+    // Should stay on register with a specific error banner visible
     await expect(page).toHaveURL(/\/register/);
-    // Backend returns 'Email or username already in use' — friendlyError falls back to 'Registration failed'
-    await expect(page.locator('text=Registration failed')).toBeVisible({ timeout: 5000 });
+    await expect(page.locator('text=An account with this email already exists')).toBeVisible({ timeout: 5000 });
   });
 
   test('login with correct credentials lands on dashboard', async ({ page }) => {

--- a/web/e2e/career.spec.ts
+++ b/web/e2e/career.spec.ts
@@ -64,5 +64,7 @@ test.describe('Career — Applications', () => {
     await page.goto('/resumes');
     // The resumes page should load (even if empty)
     await expect(page.getByRole('heading').filter({ hasText: /resumes/i })).toBeVisible({ timeout: 8_000 });
+    // Upload input should be present
+    await expect(page.locator('input[type="file"]')).toBeAttached();
   });
 });

--- a/web/index.html
+++ b/web/index.html
@@ -9,7 +9,7 @@
 
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="referrer" content="strict-origin-when-cross-origin" />
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://apis.google.com; worker-src blob:; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data: blob: https://res.cloudinary.com https://*.googleusercontent.com; connect-src 'self' http://localhost:5000 ws://localhost:5000 http://localhost:5001 ws://localhost:5001 https: wss:; frame-src https://docs.google.com https://accounts.google.com;" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://apis.google.com; worker-src blob:; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data: blob: https://res.cloudinary.com https://*.googleusercontent.com; connect-src 'self' http://localhost:5000 ws://localhost:5000 http://localhost:5001 ws://localhost:5001 https: wss:; frame-src https://docs.google.com https://accounts.google.com https://res.cloudinary.com;" />
 
     <!-- Base SEO (overridden per-page by TitleManager) -->
     <title>Continuum | The Student Workspace</title>

--- a/web/src/components/comments/CommentThread.jsx
+++ b/web/src/components/comments/CommentThread.jsx
@@ -1,4 +1,4 @@
-import { useState, useRef } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { MessageCircle, Heart, Trash, Send } from 'lucide-react';
@@ -12,7 +12,7 @@ const getAuthor = (c) => c.userSnapshot || {};
 const fullName = (u) =>
   [u?.firstName, u?.lastName].filter(Boolean).join(' ') || u?.username || 'Unknown';
 
-export default function CommentThread({ targetType, targetId, user, isDemo }) {
+export default function CommentThread({ targetType, targetId, user, isDemo, scrollToCommentId }) {
   const [commentText, setCommentText] = useState('');
   const [replyTo, setReplyTo] = useState(null); // { commentId, username } | null
   const [expandedReplies, setExpandedReplies] = useState({}); // { [commentId]: bool }
@@ -28,6 +28,16 @@ export default function CommentThread({ targetType, targetId, user, isDemo }) {
   const allComments = data?.comments || [];
   const commentMap = new Map(allComments.map(c => [c._id, c]));
   const topLevel = allComments.filter(c => !c.parentId);
+
+  useEffect(() => {
+    if (!scrollToCommentId || !data) return;
+    const el = document.getElementById(`comment-${scrollToCommentId}`);
+    if (!el) return;
+    el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    el.style.transition = 'background 0.3s';
+    el.style.background = 'rgba(107,33,168,0.08)';
+    setTimeout(() => { el.style.background = 'transparent'; }, 1800);
+  }, [scrollToCommentId, data]);
   const repliesByParent = allComments.reduce((acc, c) => {
     if (c.parentId) {
       (acc[c.parentId] ??= []).push(c);
@@ -91,7 +101,7 @@ export default function CommentThread({ targetType, targetId, user, isDemo }) {
     const likeCount = c.likes?.length || 0;
 
     return (
-      <div key={c._id} className="group" style={{ display: 'flex', gap: 12 }}>
+      <div key={c._id} id={`comment-${c._id}`} className="group" style={{ display: 'flex', gap: 12, borderRadius: 8, padding: '4px 0', transition: 'background 0.3s' }}>
         <Link
           to="/users/view"
           state={{ id: c.userId?._id ?? c.userId }}

--- a/web/src/components/layout/MessagesLayout.jsx
+++ b/web/src/components/layout/MessagesLayout.jsx
@@ -33,7 +33,10 @@ export default function MessagesLayout() {
   const [activeConversationId, setActiveConversationId] = useState(state?.conversationId ?? null);
 
   useEffect(() => {
-    if (state?.conversationId) window.history.replaceState({}, '');
+    if (state?.conversationId) {
+      queryClient.invalidateQueries({ queryKey: ['conversations'] });
+      window.history.replaceState({}, '');
+    }
   }, []);
 
   const { data, isLoading } = useQuery({

--- a/web/src/components/layout/MessagesLayout.jsx
+++ b/web/src/components/layout/MessagesLayout.jsx
@@ -31,7 +31,6 @@ export default function MessagesLayout() {
   const { data, isLoading } = useQuery({
     queryKey: ['conversations'],
     queryFn: () => api.get('/conversations').then(r => r.data),
-    refetchInterval: 8000,
   });
 
   const { data: friendsData } = useQuery({

--- a/web/src/components/layout/MessagesLayout.jsx
+++ b/web/src/components/layout/MessagesLayout.jsx
@@ -16,6 +16,14 @@ function getName(p) {
   return [p?.firstName, p?.lastName].filter(Boolean).join(' ') || p?.username || 'Unknown';
 }
 
+function previewText(content) {
+  if (!content) return '';
+  if (/^\[shared:note:/i.test(content)) return 'Shared a note';
+  if (/^\[shared:flashcardSet:/i.test(content)) return 'Shared flashcards';
+  if (/^\[shared:task:/i.test(content)) return 'Shared a task';
+  return truncate(content, 50);
+}
+
 export default function MessagesLayout() {
   const { user } = useAuth();
   const { state } = useLocation();
@@ -168,7 +176,7 @@ export default function MessagesLayout() {
                     </div>
                     {lastMsg ? (
                       <p style={{ fontSize: 12, color: '#9CA3AF', margin: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                        {isLastMine ? 'You: ' : ''}{truncate(lastMsg.content, 50)}
+                        {isLastMine ? 'You: ' : ''}{previewText(lastMsg.content)}
                       </p>
                     ) : (
                       <p style={{ fontSize: 12, color: '#9CA3AF', margin: 0, fontStyle: 'italic' }}>No messages yet</p>

--- a/web/src/components/tasks/TaskDetailModal.jsx
+++ b/web/src/components/tasks/TaskDetailModal.jsx
@@ -37,7 +37,7 @@ const TYPE_COLORS = {
 //   onClose  — callback
 //   onUpdated — optional callback after a successful mutation (use to invalidate parent queries)
 // ----------------------------------------
-export default function TaskDetailModal({ taskId, open, onClose, onUpdated }) {
+export default function TaskDetailModal({ taskId, open, onClose, onUpdated, scrollToCommentId }) {
   const { user } = useAuth();
   const [editing, setEditing] = useState(false);
   const [editForm, setEditForm] = useState({});
@@ -476,7 +476,7 @@ export default function TaskDetailModal({ taskId, open, onClose, onUpdated }) {
 
           {/* Comments */}
           <div style={{ borderTop: '1px solid #E5E7EB', paddingTop: 16, marginTop: 4 }}>
-            <CommentThread targetType="task" targetId={taskId} user={user} isDemo={false} />
+            <CommentThread targetType="task" targetId={taskId} user={user} isDemo={false} scrollToCommentId={scrollToCommentId} />
           </div>
 
           {/* Actions */}

--- a/web/src/components/ui/ActivityFeedItem.jsx
+++ b/web/src/components/ui/ActivityFeedItem.jsx
@@ -64,8 +64,17 @@ function getRowNav(item) {
     case 'note_shared':    return { to: '/notes/view', state: { id: item.targetId } };
     case 'flashcard_shared': return { to: '/flashcards/view', state: { id: item.targetId } };
     case 'task_created':   return { to: '/tasks', state: { openTaskId: item.targetId } };
-    case 'comment_added':  return resourceNav(item.targetType, item.targetId);
-    case 'like_added':     return m.resourceId ? resourceNav(m.resourceType, m.resourceId) : null;
+    case 'comment_added': {
+      const base = resourceNav(item.targetType, item.targetId);
+      if (!base) return null;
+      return m.commentId ? { to: base.to, state: { ...base.state, commentId: m.commentId } } : base;
+    }
+    case 'like_added': {
+      if (!m.resourceId) return null;
+      const base = resourceNav(m.resourceType, m.resourceId);
+      if (!base) return null;
+      return m.commentId ? { to: base.to, state: { ...base.state, commentId: m.commentId } } : base;
+    }
     default: return null;
   }
 }
@@ -96,13 +105,15 @@ export function getActivitySentence(item, actor) {
     case 'task_created':
       return <>{bold} shared a task {m.taskTitle && contentLink('/tasks', { openTaskId: item.targetId }, m.taskTitle)}{suffix}</>;
     case 'comment_added': {
-      const nav = resourceNav(item.targetType, item.targetId);
+      const base = resourceNav(item.targetType, item.targetId);
+      const nav = base && m.commentId ? { to: base.to, state: { ...base.state, commentId: m.commentId } } : base;
       return m.commentPreview
         ? <>{bold} commented: {nav ? contentLink(nav.to, nav.state, m.commentPreview) : <span style={{ color: '#9CA3AF', fontStyle: 'italic' }}>"{m.commentPreview}"</span>}</>
         : <>{bold} left a comment</>;
     }
     case 'like_added': {
-      const nav = m.resourceId ? resourceNav(m.resourceType, m.resourceId) : null;
+      const base = m.resourceId ? resourceNav(m.resourceType, m.resourceId) : null;
+      const nav = base && m.commentId ? { to: base.to, state: { ...base.state, commentId: m.commentId } } : base;
       return m.commentPreview
         ? <>{bold} liked your comment: {nav ? contentLink(nav.to, nav.state, m.commentPreview) : <span style={{ color: '#9CA3AF', fontStyle: 'italic' }}>"{m.commentPreview}"</span>}</>
         : <>{bold} liked a comment</>;

--- a/web/src/components/ui/ActivityFeedItem.jsx
+++ b/web/src/components/ui/ActivityFeedItem.jsx
@@ -1,0 +1,118 @@
+import { Link } from 'react-router-dom';
+import AppAvatar from '@/components/ui/AppAvatar';
+import VerifiedBadge from '@/components/ui/VerifiedBadge';
+import { formatRelative } from '@/lib/utils';
+
+function fullName(u) {
+  return [u?.firstName, u?.lastName].filter(Boolean).join(' ') || u?.username || 'Someone';
+}
+
+const nameLink = (u) => (
+  <span key={u._id} style={{ display: 'inline-flex', alignItems: 'center', gap: 3 }}>
+    <Link
+      to="/users/view"
+      state={{ id: u._id }}
+      style={{ color: '#6b21a8', fontWeight: 600, textDecoration: 'none' }}
+      onMouseEnter={e => e.currentTarget.style.textDecoration = 'underline'}
+      onMouseLeave={e => e.currentTarget.style.textDecoration = 'none'}
+    >
+      {[u.firstName, u.lastName].filter(Boolean).join(' ') || 'Someone'}
+    </Link>
+    <VerifiedBadge roles={u.roles} />
+  </span>
+);
+
+function renderNames(names) {
+  if (!names || names.length === 0) return null;
+  if (names.length === 1) return nameLink(names[0]);
+  if (names.length === 2) return <>{nameLink(names[0])} and {nameLink(names[1])}</>;
+  return <>{nameLink(names[0])}, {nameLink(names[1])}, and {names.length - 2} other{names.length - 2 !== 1 ? 's' : ''}</>;
+}
+
+function shareSuffix(m) {
+  if (m.isRecipient) return <> with you</>;
+  if (m.sharedWithAll) return <> with friends</>;
+  if (m.sharedWithNames?.length > 0) return <> with {renderNames(m.sharedWithNames)}</>;
+  return null;
+}
+
+const contentLink = (to, state, text) => (
+  <Link
+    to={to}
+    state={state}
+    style={{ color: '#6b21a8', fontStyle: 'italic', fontWeight: 500, textDecoration: 'none' }}
+    onMouseEnter={e => e.currentTarget.style.textDecoration = 'underline'}
+    onMouseLeave={e => e.currentTarget.style.textDecoration = 'none'}
+  >
+    "{text}"
+  </Link>
+);
+
+const resourceNav = (type, id) => {
+  if (type === 'note') return { to: '/notes/view', state: { id } };
+  if (type === 'flashcardSet') return { to: '/flashcards/view', state: { id } };
+  if (type === 'task') return { to: '/tasks', state: { openTaskId: id } };
+  return null;
+};
+
+export function getActivitySentence(item, actor) {
+  const m = item.metadata || {};
+  const name = fullName(actor);
+  const bold = (
+    <span style={{ display: 'inline-flex', alignItems: 'center', gap: 3 }}>
+      <Link to="/users/view" state={{ id: actor?._id }} style={{ fontWeight: 700, color: '#111827', textDecoration: 'none' }}>
+        {name}
+      </Link>
+      <VerifiedBadge roles={actor?.roles} />
+    </span>
+  );
+  const suffix = shareSuffix(m);
+
+  switch (item.type) {
+    case 'note_shared':
+      return <>{bold} shared their note {m.noteTitle && contentLink('/notes/view', { id: item.targetId }, m.noteTitle)}{suffix}</>;
+    case 'flashcard_shared':
+      return <>{bold} shared a flashcard set {m.setTitle && contentLink('/flashcards/view', { id: item.targetId }, m.setTitle)}{suffix}</>;
+    case 'task_created':
+      return <>{bold} shared a task {m.taskTitle && contentLink('/tasks', { openTaskId: item.targetId }, m.taskTitle)}{suffix}</>;
+    case 'comment_added': {
+      const nav = resourceNav(item.targetType, item.targetId);
+      return m.commentPreview
+        ? <>{bold} commented: {nav ? contentLink(nav.to, nav.state, m.commentPreview) : <span style={{ color: '#9CA3AF', fontStyle: 'italic' }}>"{m.commentPreview}"</span>}</>
+        : <>{bold} left a comment</>;
+    }
+    case 'like_added': {
+      const nav = m.resourceId ? resourceNav(m.resourceType, m.resourceId) : null;
+      return m.commentPreview
+        ? <>{bold} liked your comment: {nav ? contentLink(nav.to, nav.state, m.commentPreview) : <span style={{ color: '#9CA3AF', fontStyle: 'italic' }}>"{m.commentPreview}"</span>}</>
+        : <>{bold} liked a comment</>;
+    }
+    default:
+      return <>{bold} did something</>;
+  }
+}
+
+export default function ActivityFeedItem({ item, isLast = false }) {
+  const actor = item.userId;
+  const name = fullName(actor);
+
+  return (
+    <div style={{
+      display: 'flex',
+      alignItems: 'flex-start',
+      gap: 14,
+      padding: '14px 0',
+      borderBottom: isLast ? 'none' : '1px solid #E5E7EB',
+    }}>
+      <Link to="/users/view" state={{ id: actor?._id }} style={{ flexShrink: 0 }}>
+        <AppAvatar name={name} src={actor?.avatarUrl} size="sm" className="hover:opacity-80 transition-opacity" />
+      </Link>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <p style={{ fontSize: 13, color: '#374151', margin: 0, lineHeight: 1.5 }}>
+          {getActivitySentence(item, actor)}
+        </p>
+        <p style={{ fontSize: 11, color: '#9CA3AF', marginTop: 4 }}>{formatRelative(item.createdAt)}</p>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/ui/ActivityFeedItem.jsx
+++ b/web/src/components/ui/ActivityFeedItem.jsx
@@ -131,7 +131,7 @@ export default function ActivityFeedItem({ item, isLast = false }) {
         borderRadius: 4,
         transition: 'background 0.1s',
       }}
-      onMouseEnter={e => { if (rowNav) e.currentTarget.style.background = 'rgba(107,33,168,0.03)'; }}
+      onMouseEnter={e => { if (rowNav) e.currentTarget.style.background = 'rgba(107,33,168,0.08)'; }}
       onMouseLeave={e => { e.currentTarget.style.background = 'transparent'; }}
     >
       {/* Avatar — links to the actor's profile, stops row click */}

--- a/web/src/components/ui/ActivityFeedItem.jsx
+++ b/web/src/components/ui/ActivityFeedItem.jsx
@@ -1,4 +1,4 @@
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import AppAvatar from '@/components/ui/AppAvatar';
 import VerifiedBadge from '@/components/ui/VerifiedBadge';
 import { formatRelative } from '@/lib/utils';
@@ -13,6 +13,7 @@ const nameLink = (u) => (
       to="/users/view"
       state={{ id: u._id }}
       style={{ color: '#6b21a8', fontWeight: 600, textDecoration: 'none' }}
+      onClick={e => e.stopPropagation()}
       onMouseEnter={e => e.currentTarget.style.textDecoration = 'underline'}
       onMouseLeave={e => e.currentTarget.style.textDecoration = 'none'}
     >
@@ -41,6 +42,7 @@ const contentLink = (to, state, text) => (
     to={to}
     state={state}
     style={{ color: '#6b21a8', fontStyle: 'italic', fontWeight: 500, textDecoration: 'none' }}
+    onClick={e => e.stopPropagation()}
     onMouseEnter={e => e.currentTarget.style.textDecoration = 'underline'}
     onMouseLeave={e => e.currentTarget.style.textDecoration = 'none'}
   >
@@ -55,12 +57,30 @@ const resourceNav = (type, id) => {
   return null;
 };
 
+// Primary destination for the whole row — used for the row-level click
+function getRowNav(item) {
+  const m = item.metadata || {};
+  switch (item.type) {
+    case 'note_shared':    return { to: '/notes/view', state: { id: item.targetId } };
+    case 'flashcard_shared': return { to: '/flashcards/view', state: { id: item.targetId } };
+    case 'task_created':   return { to: '/tasks', state: { openTaskId: item.targetId } };
+    case 'comment_added':  return resourceNav(item.targetType, item.targetId);
+    case 'like_added':     return m.resourceId ? resourceNav(m.resourceType, m.resourceId) : null;
+    default: return null;
+  }
+}
+
 export function getActivitySentence(item, actor) {
   const m = item.metadata || {};
   const name = fullName(actor);
   const bold = (
     <span style={{ display: 'inline-flex', alignItems: 'center', gap: 3 }}>
-      <Link to="/users/view" state={{ id: actor?._id }} style={{ fontWeight: 700, color: '#111827', textDecoration: 'none' }}>
+      <Link
+        to="/users/view"
+        state={{ id: actor?._id }}
+        style={{ fontWeight: 700, color: '#111827', textDecoration: 'none' }}
+        onClick={e => e.stopPropagation()}
+      >
         {name}
       </Link>
       <VerifiedBadge roles={actor?.roles} />
@@ -95,18 +115,32 @@ export function getActivitySentence(item, actor) {
 export default function ActivityFeedItem({ item, isLast = false }) {
   const actor = item.userId;
   const name = fullName(actor);
+  const navigate = useNavigate();
+  const rowNav = getRowNav(item);
 
   return (
-    <div style={{
-      display: 'flex',
-      alignItems: 'flex-start',
-      gap: 14,
-      padding: '14px 0',
-      borderBottom: isLast ? 'none' : '1px solid #E5E7EB',
-    }}>
-      <Link to="/users/view" state={{ id: actor?._id }} style={{ flexShrink: 0 }}>
-        <AppAvatar name={name} src={actor?.avatarUrl} size="sm" className="hover:opacity-80 transition-opacity" />
-      </Link>
+    <div
+      onClick={rowNav ? () => navigate(rowNav.to, { state: rowNav.state }) : undefined}
+      style={{
+        display: 'flex',
+        alignItems: 'flex-start',
+        gap: 14,
+        padding: '14px 0',
+        borderBottom: isLast ? 'none' : '1px solid #E5E7EB',
+        cursor: rowNav ? 'pointer' : 'default',
+        borderRadius: 4,
+        transition: 'background 0.1s',
+      }}
+      onMouseEnter={e => { if (rowNav) e.currentTarget.style.background = 'rgba(107,33,168,0.03)'; }}
+      onMouseLeave={e => { e.currentTarget.style.background = 'transparent'; }}
+    >
+      {/* Avatar — links to the actor's profile, stops row click */}
+      <div onClick={e => e.stopPropagation()} style={{ flexShrink: 0 }}>
+        <Link to="/users/view" state={{ id: actor?._id }}>
+          <AppAvatar name={name} src={actor?.avatarUrl} size="sm" className="hover:opacity-80 transition-opacity" />
+        </Link>
+      </div>
+
       <div style={{ flex: 1, minWidth: 0 }}>
         <p style={{ fontSize: 13, color: '#374151', margin: 0, lineHeight: 1.5 }}>
           {getActivitySentence(item, actor)}

--- a/web/src/components/ui/Modal.jsx
+++ b/web/src/components/ui/Modal.jsx
@@ -3,7 +3,7 @@ import { createPortal } from 'react-dom';
 import { X } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
-export default function Modal({ open, onClose, title, children, className }) {
+export default function Modal({ open, onClose, title, children, className, containerStyle }) {
   useEffect(() => {
     if (!open) return;
     const handler = (e) => e.key === 'Escape' && onClose?.();
@@ -26,8 +26,8 @@ export default function Modal({ open, onClose, title, children, className }) {
         )}
         style={{
           border: '1px solid #E5E7EB',
-          boxShadow:
-            '0 25px 50px -12px rgba(0,0,0,0.25), 0 0 0 1px rgba(107,33,168,0.04)',
+          boxShadow: '0 25px 50px -12px rgba(0,0,0,0.25), 0 0 0 1px rgba(107,33,168,0.04)',
+          ...containerStyle,
         }}
       >
         <div

--- a/web/src/context/AuthContext.jsx
+++ b/web/src/context/AuthContext.jsx
@@ -52,6 +52,11 @@ function registerSocketEvents(socket) {
     queryClient.invalidateQueries({ queryKey: ['activity'] });
   });
 
+  // Someone liked your comment
+  socket.on('like_added', () => {
+    queryClient.invalidateQueries({ queryKey: ['activity'] });
+  });
+
   // Flashcard set shared with you
   socket.on('flashcard_shared', () => {
     queryClient.invalidateQueries({ queryKey: ['flashcard-sets'] });

--- a/web/src/context/AuthContext.jsx
+++ b/web/src/context/AuthContext.jsx
@@ -36,12 +36,16 @@ function registerSocketEvents(socket) {
     queryClient.invalidateQueries({ queryKey: ['calendar'] });
   });
 
-  // Note updates and shares
+  // Note updates, shares, and deletions
   socket.on('note_updated', () => {
     queryClient.invalidateQueries({ queryKey: ['notes'] });
   });
   socket.on('note_shared', () => {
     queryClient.invalidateQueries({ queryKey: ['notes'] });
+  });
+  socket.on('note_deleted', ({ noteId }) => {
+    queryClient.invalidateQueries({ queryKey: ['notes'] });
+    queryClient.removeQueries({ queryKey: ['note', noteId] });
   });
 
   // New comment on something you own
@@ -57,9 +61,13 @@ function registerSocketEvents(socket) {
     queryClient.invalidateQueries({ queryKey: ['activity'] });
   });
 
-  // Flashcard set shared with you
+  // Flashcard set shared with or deleted for you
   socket.on('flashcard_shared', () => {
     queryClient.invalidateQueries({ queryKey: ['flashcard-sets'] });
+  });
+  socket.on('flashcard_set_deleted', ({ setId }) => {
+    queryClient.invalidateQueries({ queryKey: ['flashcard-sets'] });
+    queryClient.removeQueries({ queryKey: ['flashcard-set', setId] });
   });
 
   // Activity feed — someone's action just appeared in your feed

--- a/web/src/lib/api.js
+++ b/web/src/lib/api.js
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { updateSocketToken } from '@/lib/socket';
 
 const api = axios.create({
   baseURL: (import.meta.env.VITE_API_URL || 'http://localhost:5001') + '/api',
@@ -84,6 +85,7 @@ api.interceptors.response.use(
 
       try {
         const newToken = await refreshPromise;
+        updateSocketToken(newToken);
         err.config.headers.Authorization = `Bearer ${newToken}`;
         return api(err.config);
       } catch {

--- a/web/src/lib/socket.js
+++ b/web/src/lib/socket.js
@@ -22,6 +22,10 @@ export function getSocket() {
   return socket;
 }
 
+export function updateSocketToken(token) {
+  if (socket) socket.auth = { token };
+}
+
 export function disconnectSocket() {
   socket?.disconnect();
   socket = null;

--- a/web/src/pages/Activity.jsx
+++ b/web/src/pages/Activity.jsx
@@ -57,11 +57,11 @@ function getActivitySentence(item, actor) {
   );
   const suffix = shareSuffix(m);
 
-  const titleLink = (to, state, text) => (
+  const contentLink = (to, state, text, style = {}) => (
     <Link
       to={to}
       state={state}
-      style={{ color: '#9CA3AF', fontStyle: 'italic', textDecoration: 'none' }}
+      style={{ color: '#6b21a8', fontStyle: 'italic', fontWeight: 500, textDecoration: 'none', ...style }}
       onMouseEnter={e => e.currentTarget.style.textDecoration = 'underline'}
       onMouseLeave={e => e.currentTarget.style.textDecoration = 'none'}
     >
@@ -69,21 +69,32 @@ function getActivitySentence(item, actor) {
     </Link>
   );
 
+  const resourceNav = (type, id) => {
+    if (type === 'note') return { to: '/notes/view', state: { id } };
+    if (type === 'flashcardSet') return { to: '/flashcards/view', state: { id } };
+    if (type === 'task') return { to: '/tasks', state: { openTaskId: id } };
+    return null;
+  };
+
   switch (item.type) {
     case 'note_shared':
-      return <>{bold} shared their note {m.noteTitle && titleLink('/notes/view', { id: item.targetId }, m.noteTitle)}{suffix}</>;
+      return <>{bold} shared their note {m.noteTitle && contentLink('/notes/view', { id: item.targetId }, m.noteTitle)}{suffix}</>;
     case 'flashcard_shared':
-      return <>{bold} shared a flashcard set {m.setTitle && titleLink('/flashcards/view', { id: item.targetId }, m.setTitle)}{suffix}</>;
+      return <>{bold} shared a flashcard set {m.setTitle && contentLink('/flashcards/view', { id: item.targetId }, m.setTitle)}{suffix}</>;
     case 'task_created':
-      return <>{bold} shared a task {m.taskTitle && titleLink('/tasks', { openTaskId: item.targetId }, m.taskTitle)}{suffix}</>;
-    case 'comment_added':
+      return <>{bold} shared a task {m.taskTitle && contentLink('/tasks', { openTaskId: item.targetId }, m.taskTitle)}{suffix}</>;
+    case 'comment_added': {
+      const nav = resourceNav(item.targetType, item.targetId);
       return m.commentPreview
-        ? <>{bold} commented: <span style={{ color: '#9CA3AF' }}>"{m.commentPreview}"</span></>
+        ? <>{bold} commented: {nav ? contentLink(nav.to, nav.state, m.commentPreview) : <span style={{ color: '#9CA3AF', fontStyle: 'italic' }}>"{m.commentPreview}"</span>}</>
         : <>{bold} left a comment</>;
-    case 'like_added':
+    }
+    case 'like_added': {
+      const nav = m.resourceId ? resourceNav(m.resourceType, m.resourceId) : null;
       return m.commentPreview
-        ? <>{bold} liked a comment: <span style={{ color: '#9CA3AF' }}>"{m.commentPreview}"</span></>
+        ? <>{bold} liked your comment: {nav ? contentLink(nav.to, nav.state, m.commentPreview) : <span style={{ color: '#9CA3AF', fontStyle: 'italic' }}>"{m.commentPreview}"</span>}</>
         : <>{bold} liked a comment</>;
+    }
     default:
       return <>{bold} did something</>;
   }

--- a/web/src/pages/Activity.jsx
+++ b/web/src/pages/Activity.jsx
@@ -2,132 +2,10 @@ import { useState, useEffect } from 'react';
 import { useInfiniteQuery, useQueryClient } from '@tanstack/react-query';
 import { useAuth } from '@/context/AuthContext';
 import { Activity as ActivityIcon, Search } from 'lucide-react';
-import { Link } from 'react-router-dom';
 import api from '@/lib/api';
-import AppAvatar from '@/components/ui/AppAvatar';
 import Button from '@/components/ui/Button';
-import Skeleton from '@/components/ui/Skeleton';
 import ActivitySkeleton from '@/components/skeletons/ActivitySkeleton';
-import { formatRelative } from '@/lib/utils';
-import VerifiedBadge from '@/components/ui/VerifiedBadge';
-
-function fullName(u) {
-  return [u?.firstName, u?.lastName].filter(Boolean).join(' ') || u?.username || 'Someone';
-}
-
-const nameLink = (u) => (
-  <span key={u._id} style={{ display: 'inline-flex', alignItems: 'center', gap: 3 }}>
-    <Link
-      to="/users/view"
-      state={{ id: u._id }}
-      style={{ color: '#6b21a8', fontWeight: 600, textDecoration: 'none' }}
-      onMouseEnter={e => e.currentTarget.style.textDecoration = 'underline'}
-      onMouseLeave={e => e.currentTarget.style.textDecoration = 'none'}
-    >
-      {[u.firstName, u.lastName].filter(Boolean).join(' ') || 'Someone'}
-    </Link>
-    <VerifiedBadge roles={u.roles} />
-  </span>
-);
-
-function renderNames(names) {
-  if (!names || names.length === 0) return null;
-  if (names.length === 1) return nameLink(names[0]);
-  if (names.length === 2) return <>{nameLink(names[0])} and {nameLink(names[1])}</>;
-  return <>{nameLink(names[0])}, {nameLink(names[1])}, and {names.length - 2} other{names.length - 2 !== 1 ? 's' : ''}</>;
-}
-
-function shareSuffix(m) {
-  if (m.isRecipient) return <> with you</>;
-  if (m.sharedWithAll) return <> with friends</>;
-  if (m.sharedWithNames?.length > 0) return <> with {renderNames(m.sharedWithNames)}</>;
-  return null;
-}
-
-function getActivitySentence(item, actor) {
-  const m = item.metadata || {};
-  const name = fullName(actor);
-  const bold = (
-    <span style={{ display: 'inline-flex', alignItems: 'center', gap: 3 }}>
-      <Link to="/users/view" state={{ id: actor?._id }} style={{ fontWeight: 700, color: '#111827', textDecoration: 'none' }}>
-        {name}
-      </Link>
-      <VerifiedBadge roles={actor?.roles} />
-    </span>
-  );
-  const suffix = shareSuffix(m);
-
-  const contentLink = (to, state, text, style = {}) => (
-    <Link
-      to={to}
-      state={state}
-      style={{ color: '#6b21a8', fontStyle: 'italic', fontWeight: 500, textDecoration: 'none', ...style }}
-      onMouseEnter={e => e.currentTarget.style.textDecoration = 'underline'}
-      onMouseLeave={e => e.currentTarget.style.textDecoration = 'none'}
-    >
-      "{text}"
-    </Link>
-  );
-
-  const resourceNav = (type, id) => {
-    if (type === 'note') return { to: '/notes/view', state: { id } };
-    if (type === 'flashcardSet') return { to: '/flashcards/view', state: { id } };
-    if (type === 'task') return { to: '/tasks', state: { openTaskId: id } };
-    return null;
-  };
-
-  switch (item.type) {
-    case 'note_shared':
-      return <>{bold} shared their note {m.noteTitle && contentLink('/notes/view', { id: item.targetId }, m.noteTitle)}{suffix}</>;
-    case 'flashcard_shared':
-      return <>{bold} shared a flashcard set {m.setTitle && contentLink('/flashcards/view', { id: item.targetId }, m.setTitle)}{suffix}</>;
-    case 'task_created':
-      return <>{bold} shared a task {m.taskTitle && contentLink('/tasks', { openTaskId: item.targetId }, m.taskTitle)}{suffix}</>;
-    case 'comment_added': {
-      const nav = resourceNav(item.targetType, item.targetId);
-      return m.commentPreview
-        ? <>{bold} commented: {nav ? contentLink(nav.to, nav.state, m.commentPreview) : <span style={{ color: '#9CA3AF', fontStyle: 'italic' }}>"{m.commentPreview}"</span>}</>
-        : <>{bold} left a comment</>;
-    }
-    case 'like_added': {
-      const nav = m.resourceId ? resourceNav(m.resourceType, m.resourceId) : null;
-      return m.commentPreview
-        ? <>{bold} liked your comment: {nav ? contentLink(nav.to, nav.state, m.commentPreview) : <span style={{ color: '#9CA3AF', fontStyle: 'italic' }}>"{m.commentPreview}"</span>}</>
-        : <>{bold} liked a comment</>;
-    }
-    default:
-      return <>{bold} did something</>;
-  }
-}
-
-function ActivityItem({ item }) {
-  const actor = item.userId;
-  const name = fullName(actor);
-  const actorId = actor?._id;
-
-  return (
-    <div style={{
-      display: 'flex',
-      alignItems: 'flex-start',
-      gap: 14,
-      padding: '14px 0',
-      borderBottom: '1px solid #E5E7EB',
-    }}>
-      <div style={{ flexShrink: 0 }}>
-        <Link to="/users/view" state={{ id: actorId }} style={{ display: 'block' }}>
-          <AppAvatar name={name} src={actor?.avatarUrl} size="sm" className="hover:opacity-80 transition-opacity" />
-        </Link>
-      </div>
-
-      <div style={{ flex: 1, minWidth: 0 }}>
-        <p style={{ fontSize: 13, color: '#374151', margin: 0, lineHeight: 1.5 }}>
-          {getActivitySentence(item, actor)}
-        </p>
-        <p style={{ fontSize: 11, color: '#9CA3AF', marginTop: 4 }}>{formatRelative(item.createdAt)}</p>
-      </div>
-    </div>
-  );
-}
+import ActivityFeedItem from '@/components/ui/ActivityFeedItem';
 
 const PAGE_SIZE = 20;
 
@@ -136,12 +14,10 @@ export default function Activity() {
   const { updateUser } = useAuth();
   const queryClient = useQueryClient();
 
-  // Mark activities as seen — persists server-side so count resets on any device
   useEffect(() => {
     api.put('/activity/mark-seen').then(() => {
       const now = new Date().toISOString();
       updateUser({ lastViewedActivityAt: now });
-      // Invalidate Dashboard's activity query so it refetches with count = 0
       queryClient.invalidateQueries({ queryKey: ['activity'] });
     }).catch(() => {});
   }, []);
@@ -170,7 +46,6 @@ export default function Activity() {
 
   return (
     <div>
-      {/* Page header */}
       <div style={{ marginBottom: 16 }}>
         <h1 style={{ fontFamily: 'Fraunces, Georgia, serif', fontSize: '1.625rem', fontWeight: 700, color: '#111827', margin: 0 }}>
           Activity
@@ -180,7 +55,6 @@ export default function Activity() {
         </p>
       </div>
 
-      {/* Search */}
       <div style={{ position: 'relative', marginBottom: 24 }}>
         <Search size={14} style={{ position: 'absolute', left: 12, top: '50%', transform: 'translateY(-50%)', color: '#9CA3AF', pointerEvents: 'none' }} />
         <input
@@ -233,19 +107,15 @@ export default function Activity() {
               </p>
             </div>
           ) : (
-            activities.map(item => <ActivityItem key={item._id} item={item} />)
+            activities.map((item, idx) => (
+              <ActivityFeedItem key={item._id} item={item} isLast={idx === activities.length - 1} />
+            ))
           )}
         </div>
 
-        {/* Load more */}
         {hasNextPage && (
           <div style={{ padding: '16px 20px', borderTop: '1px solid #E5E7EB', textAlign: 'center' }}>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => fetchNextPage()}
-              loading={isFetchingNextPage}
-            >
+            <Button variant="outline" size="sm" onClick={() => fetchNextPage()} loading={isFetchingNextPage}>
               Load more
             </Button>
           </div>

--- a/web/src/pages/Activity.jsx
+++ b/web/src/pages/Activity.jsx
@@ -77,19 +77,10 @@ function getActivitySentence(item, actor) {
   }
 }
 
-const TYPE_COLORS = {
-  note_shared: '#6b21a8',
-  flashcard_shared: '#6b21a8',
-  task_created: '#6b21a8',
-  comment_added: '#6b21a8',
-  like_added: '#6b21a8',
-};
-
 function ActivityItem({ item }) {
   const actor = item.userId;
   const name = fullName(actor);
   const actorId = actor?._id;
-  const dotColor = TYPE_COLORS[item.type] || '#9CA3AF';
 
   return (
     <div style={{
@@ -98,23 +89,11 @@ function ActivityItem({ item }) {
       gap: 14,
       padding: '14px 0',
       borderBottom: '1px solid #E5E7EB',
-      position: 'relative',
     }}>
-      {/* Activity type dot */}
-      <div style={{ position: 'relative', flexShrink: 0 }}>
+      <div style={{ flexShrink: 0 }}>
         <Link to="/users/view" state={{ id: actorId }} style={{ display: 'block' }}>
           <AppAvatar name={name} src={actor?.avatarUrl} size="sm" className="hover:opacity-80 transition-opacity" />
         </Link>
-        <div style={{
-          position: 'absolute',
-          bottom: -2,
-          right: -2,
-          width: 10,
-          height: 10,
-          borderRadius: '50%',
-          background: dotColor,
-          border: '2px solid #fff',
-        }} />
       </div>
 
       <div style={{ flex: 1, minWidth: 0 }}>

--- a/web/src/pages/Activity.jsx
+++ b/web/src/pages/Activity.jsx
@@ -57,13 +57,25 @@ function getActivitySentence(item, actor) {
   );
   const suffix = shareSuffix(m);
 
+  const titleLink = (to, state, text) => (
+    <Link
+      to={to}
+      state={state}
+      style={{ color: '#9CA3AF', fontStyle: 'italic', textDecoration: 'none' }}
+      onMouseEnter={e => e.currentTarget.style.textDecoration = 'underline'}
+      onMouseLeave={e => e.currentTarget.style.textDecoration = 'none'}
+    >
+      "{text}"
+    </Link>
+  );
+
   switch (item.type) {
     case 'note_shared':
-      return <>{bold} shared their note {m.noteTitle && <span style={{ color: '#9CA3AF' }}>"{m.noteTitle}"</span>}{suffix}</>;
+      return <>{bold} shared their note {m.noteTitle && titleLink('/notes/view', { id: item.targetId }, m.noteTitle)}{suffix}</>;
     case 'flashcard_shared':
-      return <>{bold} shared a flashcard set {m.setTitle && <span style={{ color: '#9CA3AF' }}>"{m.setTitle}"</span>}{suffix}</>;
+      return <>{bold} shared a flashcard set {m.setTitle && titleLink('/flashcards/view', { id: item.targetId }, m.setTitle)}{suffix}</>;
     case 'task_created':
-      return <>{bold} shared a task {m.taskTitle && <span style={{ color: '#9CA3AF' }}>"{m.taskTitle}"</span>}{suffix}</>;
+      return <>{bold} shared a task {m.taskTitle && titleLink('/tasks', { openTaskId: item.targetId }, m.taskTitle)}{suffix}</>;
     case 'comment_added':
       return m.commentPreview
         ? <>{bold} commented: <span style={{ color: '#9CA3AF' }}>"{m.commentPreview}"</span></>

--- a/web/src/pages/Dashboard.jsx
+++ b/web/src/pages/Dashboard.jsx
@@ -7,6 +7,7 @@ import Skeleton from '@/components/ui/Skeleton';
 import DashboardSkeleton from '@/components/skeletons/DashboardSkeleton';
 import { formatRelative, truncate, stripHtml } from '@/lib/utils';
 import VerifiedBadge from '@/components/ui/VerifiedBadge';
+import ActivityFeedItem from '@/components/ui/ActivityFeedItem';
 
 // Verified backend response shapes:
 // GET /notes → { notes[], pagination: { total, page, limit, pages } }
@@ -403,110 +404,6 @@ function AppItem({ app }) {
   );
 }
 
-/* ────────────────────────────────────────
-   Activity Feed
-   ──────────────────────────────────────── */
-const feedNameLink = (u) => (
-  <Link
-    key={u._id}
-    to="/users/view"
-    state={{ id: u._id }}
-    style={{ color: '#6b21a8', fontWeight: 600, textDecoration: 'none' }}
-  >
-    {[u.firstName, u.lastName].filter(Boolean).join(' ') || 'Someone'}
-  </Link>
-);
-
-function feedRenderNames(names) {
-  if (!names || names.length === 0) return null;
-  if (names.length === 1) return feedNameLink(names[0]);
-  if (names.length === 2) return <>{feedNameLink(names[0])} and {feedNameLink(names[1])}</>;
-  return <>{feedNameLink(names[0])}, {feedNameLink(names[1])}, and {names.length - 2} other{names.length - 2 !== 1 ? 's' : ''}</>;
-}
-
-function feedShareSuffix(m) {
-  if (m.isRecipient) return <> with you</>;
-  if (m.sharedWithAll) return <> with friends</>;
-  if (m.sharedWithNames?.length > 0) return <> with {feedRenderNames(m.sharedWithNames)}</>;
-  return null;
-}
-
-function getFeedSentence(item, actor) {
-  const m = item.metadata || {};
-  const name = fullName(actor);
-  const bold = (
-    <span style={{ display: 'inline-flex', alignItems: 'center', gap: 3 }}>
-      <Link to="/users/view" state={{ id: actor?._id }} style={{ fontWeight: 700, color: '#111827', textDecoration: 'none' }}>
-        {name}
-      </Link>
-      <VerifiedBadge roles={actor?.roles} />
-    </span>
-  );
-  const suffix = feedShareSuffix(m);
-
-  switch (item.type) {
-    case 'note_shared':
-      return <>{bold} shared their note {m.noteTitle && <span style={{ color: '#9CA3AF' }}>"{truncate(m.noteTitle, 40)}"</span>}{suffix}</>;
-    case 'flashcard_shared':
-      return <>{bold} shared a flashcard set {m.setTitle && <span style={{ color: '#9CA3AF' }}>"{truncate(m.setTitle, 40)}"</span>}{suffix}</>;
-    case 'task_created':
-      return <>{bold} shared a task {m.taskTitle && <span style={{ color: '#9CA3AF' }}>"{truncate(m.taskTitle, 40)}"</span>}{suffix}</>;
-    case 'comment_added':
-      return m.commentPreview
-        ? <>{bold} commented: <span style={{ color: '#9CA3AF' }}>"{truncate(m.commentPreview, 50)}"</span></>
-        : <>{bold} left a comment</>;
-    case 'like_added':
-      return m.commentPreview
-        ? <>{bold} liked a comment: <span style={{ color: '#9CA3AF' }}>"{truncate(m.commentPreview, 50)}"</span></>
-        : <>{bold} liked a comment</>;
-    default:
-      return <>{bold} did something</>;
-  }
-}
-
-function FeedItem({ item }) {
-  const actor = item.userId;
-  const name = fullName(actor);
-  const initial = name.charAt(0).toUpperCase();
-
-  return (
-    <div
-      style={{
-        display: 'flex',
-        alignItems: 'flex-start',
-        gap: 12,
-        padding: '11px 0',
-        borderBottom: '1px solid #E5E7EB',
-      }}
-    >
-      <Link to="/users/view" state={{ id: actor?._id }} style={{ flexShrink: 0, marginTop: 1 }}>
-        <div
-          style={{
-            width: 32,
-            height: 32,
-            borderRadius: '50%',
-            background: 'rgba(107,33,168,0.08)',
-            border: '1.5px solid rgba(107,33,168,0.15)',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            overflow: 'hidden',
-          }}
-        >
-          {actor?.avatarUrl ? (
-            <img src={actor.avatarUrl} alt={name} style={{ width: '100%', height: '100%', objectFit: 'cover' }} />
-          ) : (
-            <span style={{ fontSize: 12, fontWeight: 700, color: '#6b21a8' }}>{initial}</span>
-          )}
-        </div>
-      </Link>
-      <div style={{ flex: 1, minWidth: 0 }}>
-        <p style={{ fontSize: 13, color: '#374151', lineHeight: 1.5 }}>{getFeedSentence(item, actor)}</p>
-        <p style={{ fontSize: 11, color: '#9CA3AF', marginTop: 3 }}>{formatRelative(item.createdAt)}</p>
-      </div>
-    </div>
-  );
-}
 
 /* ────────────────────────────────────────
    Section Header
@@ -757,7 +654,9 @@ export default function Dashboard() {
                       No activity yet.
                     </p>
                   )
-                  : activities.slice(0, 5).map(item => <FeedItem key={item._id} item={item} />)
+                  : activities.slice(0, 5).map((item, idx, arr) => (
+                      <ActivityFeedItem key={item._id} item={item} isLast={idx === arr.length - 1} />
+                    ))
               }
             </div>
           </Section>

--- a/web/src/pages/UserProfile.jsx
+++ b/web/src/pages/UserProfile.jsx
@@ -4,7 +4,7 @@ import { useQuery, useMutation } from '@tanstack/react-query';
 import { useAuth } from '@/context/AuthContext';
 import {
   ArrowLeft, Calendar, AtSign, MessageCircle, UserPlus,
-  UserCheck, Clock, BookOpen, Layers, CheckSquare, Heart, UserMinus,
+  UserCheck, Clock, Layers, CheckSquare, UserMinus,
   FileText, Activity as ActivityIcon,
 } from 'lucide-react';
 import api from '@/lib/api';
@@ -16,7 +16,8 @@ import Skeleton from '@/components/ui/Skeleton';
 import ConfirmModal from '@/components/ui/ConfirmModal';
 import VerifiedBadge from '@/components/ui/VerifiedBadge';
 import SocialLinks from '@/components/ui/SocialLinks';
-import { formatDate, formatRelative } from '@/lib/utils';
+import ActivityFeedItem from '@/components/ui/ActivityFeedItem';
+import { formatDate } from '@/lib/utils';
 
 const fullName = (u) =>
   [u?.firstName, u?.lastName].filter(Boolean).join(' ') || u?.username || 'Unknown';
@@ -26,29 +27,6 @@ const NOTE_TYPE_VARIANTS = {
   todo: 'warning', journal: 'danger',
 };
 
-const ACTIVITY_ICONS = {
-  note_shared: BookOpen,
-  flashcard_shared: Layers,
-  task_created: CheckSquare,
-  comment_added: MessageCircle,
-  like_added: Heart,
-};
-
-const ACTIVITY_LABELS = {
-  note_shared: 'shared a note',
-  flashcard_shared: 'shared a flashcard set',
-  task_created: 'created a task',
-  comment_added: 'left a comment',
-  like_added: 'liked something',
-};
-
-const ACTIVITY_COLORS = {
-  note_shared: '#6b21a8',
-  flashcard_shared: '#6b21a8',
-  task_created: '#6b21a8',
-  comment_added: '#6b21a8',
-  like_added: '#6b21a8',
-};
 
 export default function UserProfile() {
   const { state } = useLocation();
@@ -568,51 +546,11 @@ export default function UserProfile() {
                 borderRadius: 16,
                 boxShadow: '0 1px 8px rgba(107,33,168,0.06)',
                 overflow: 'hidden',
+                padding: '0 20px',
               }}>
-                {recentActivity.map((item, idx) => {
-                  const Icon = ACTIVITY_ICONS[item.type] || ActivityIcon;
-                  const label = ACTIVITY_LABELS[item.type] || item.type;
-                  const color = ACTIVITY_COLORS[item.type] || '#9CA3AF';
-                  return (
-                    <div
-                      key={item._id}
-                      style={{
-                        display: 'flex',
-                        alignItems: 'flex-start',
-                        gap: 12,
-                        padding: '14px 20px',
-                        borderBottom: idx < recentActivity.length - 1 ? '1px solid #E5E7EB' : 'none',
-                      }}
-                    >
-                      <div style={{
-                        width: 32,
-                        height: 32,
-                        borderRadius: '50%',
-                        background: `${color}14`,
-                        display: 'flex',
-                        alignItems: 'center',
-                        justifyContent: 'center',
-                        flexShrink: 0,
-                        marginTop: 1,
-                      }}>
-                        <Icon size={14} style={{ color }} />
-                      </div>
-                      <div style={{ flex: 1, minWidth: 0 }}>
-                        <p style={{ fontSize: 13, color: '#374151', margin: 0 }}>
-                          <Link to="/users/view" state={{ id: profile?._id }} style={{ fontWeight: 700, color: '#111827', textDecoration: 'none' }}>{name}</Link> {label}
-                          {item.metadata?.noteTitle && (
-                            <span style={{ color: '#9CA3AF' }}> · {item.metadata.noteTitle}</span>
-                          )}
-                        </p>
-                        {item.createdAt && (
-                          <p style={{ fontSize: 11, color: '#9CA3AF', margin: '3px 0 0' }}>
-                            {formatRelative ? formatRelative(item.createdAt) : formatDate(item.createdAt)}
-                          </p>
-                        )}
-                      </div>
-                    </div>
-                  );
-                })}
+                {recentActivity.map((item, idx) => (
+                  <ActivityFeedItem key={item._id} item={item} isLast={idx === recentActivity.length - 1} />
+                ))}
               </div>
             )}
           </section>

--- a/web/src/pages/flashcards/FlashcardSetDetail.jsx
+++ b/web/src/pages/flashcards/FlashcardSetDetail.jsx
@@ -17,6 +17,7 @@ import { posthog } from '@/lib/posthog';
 export default function FlashcardSetDetail() {
   const { state } = useLocation();
   const id = state?.id;
+  const commentId = state?.commentId;
   const { user } = useAuth();
   const queryClient = useQueryClient();
   const [activeTab, setActiveTab] = useState('cards'); // 'cards' | 'history'
@@ -558,7 +559,7 @@ export default function FlashcardSetDetail() {
         padding: '24px 28px',
         marginTop: 24,
       }}>
-        <CommentThread targetType="flashcardSet" targetId={id} user={user} isDemo={user?.isDemo} />
+        <CommentThread targetType="flashcardSet" targetId={id} user={user} isDemo={user?.isDemo} scrollToCommentId={commentId} />
       </div>
 
       {/* Add card modal */}

--- a/web/src/pages/friends/Friends.jsx
+++ b/web/src/pages/friends/Friends.jsx
@@ -81,8 +81,7 @@ export default function Friends() {
     mutationFn: (friendId) => api.post('/conversations', { participantId: friendId }),
     onSuccess: (res) => {
       const convId = res.data?.conversation?._id || res.data?.data?._id;
-      if (convId) navigate(`/messages/${convId}`);
-      else navigate('/messages');
+      navigate('/messages', { state: { conversationId: convId ?? null } });
     },
   });
 

--- a/web/src/pages/messages/Conversation.jsx
+++ b/web/src/pages/messages/Conversation.jsx
@@ -66,7 +66,7 @@ export default function Conversation({ conversationId }) {
     queryKey: ['messages', conversationId, msgSearch],
     queryFn: () =>
       api.get(`/conversations/${conversationId}/messages`, { params: msgSearch ? { search: msgSearch } : {} }).then(r => r.data),
-    refetchInterval: msgSearch ? false : 5000, // disable polling while searching
+    refetchInterval: false,
   });
 
   const msgQueryKey = ['messages', conversationId, msgSearch];

--- a/web/src/pages/messages/Conversation.jsx
+++ b/web/src/pages/messages/Conversation.jsx
@@ -347,7 +347,6 @@ export default function Conversation({ conversationId }) {
                       >
                         {senderName}
                       </Link>
-                      <VerifiedBadge roles={msg.senderId?.roles} />
                     </span>
                   )}
 

--- a/web/src/pages/notes/NoteDetail.jsx
+++ b/web/src/pages/notes/NoteDetail.jsx
@@ -23,6 +23,7 @@ import { posthog } from '@/lib/posthog';
 export default function NoteDetail() {
   const { state } = useLocation();
   const id = state?.id;
+  const commentId = state?.commentId;
   const navigate = useNavigate();
   const { user } = useAuth();
   const [aiSummary, setAiSummary] = useState(null);
@@ -376,7 +377,7 @@ export default function NoteDetail() {
         boxShadow: '0 1px 8px rgba(107,33,168,0.06)',
         padding: '24px 28px',
       }}>
-        <CommentThread targetType="note" targetId={id} user={user} isDemo={user?.isDemo} />
+        <CommentThread targetType="note" targetId={id} user={user} isDemo={user?.isDemo} scrollToCommentId={commentId} />
       </div>
 
       <ConfirmModal

--- a/web/src/pages/resumes/Resumes.jsx
+++ b/web/src/pages/resumes/Resumes.jsx
@@ -23,7 +23,7 @@ export default function Resumes() {
   const { data, isLoading } = useQuery({
     queryKey: ['resumes', resumeSearch],
     queryFn: () => api.get('/resumes', { params: resumeSearch ? { search: resumeSearch } : {} }).then(r => r.data),
-    staleTime: 300_000,
+    staleTime: 60_000,
   });
 
   const handleUpload = async (file) => {

--- a/web/src/pages/resumes/Resumes.jsx
+++ b/web/src/pages/resumes/Resumes.jsx
@@ -1,12 +1,13 @@
 import { useState, useRef } from 'react';
 import { useQuery, useMutation } from '@tanstack/react-query';
-import { Plus, FileCheck, Sparkles, Download, ChevronDown, ChevronUp, History, Trash2, Search } from 'lucide-react';
+import { Plus, FileCheck, Sparkles, Download, ChevronDown, ChevronUp, History, Trash2, Search, Eye } from 'lucide-react';
 import api from '@/lib/api';
 import queryClient from '@/lib/queryClient';
 import { posthog } from '@/lib/posthog';
 import Button from '@/components/ui/Button';
 import Skeleton from '@/components/ui/Skeleton';
 import ConfirmModal from '@/components/ui/ConfirmModal';
+import Modal from '@/components/ui/Modal';
 import ResumesSkeleton from '@/components/skeletons/ResumesSkeleton';
 import { useAuth } from '@/context/AuthContext';
 import { formatDate } from '@/lib/utils';
@@ -209,6 +210,7 @@ function ResumeCard({ resume, expanded, feedbackLoading, onToggleFeedback, onAiF
   const [downloading, setDownloading] = useState(false);
   const [showHistory, setShowHistory] = useState(false);
   const [historyIndex, setHistoryIndex] = useState(0);
+  const [showPdf, setShowPdf] = useState(false);
 
   const handleDownload = async () => {
     setDownloading(true);
@@ -282,7 +284,12 @@ function ResumeCard({ resume, expanded, feedbackLoading, onToggleFeedback, onAiF
             </Button>
           )}
           {resume.fileUrl && (
-            <Button size="sm" variant="outline" onClick={handleDownload} loading={downloading}>
+            <Button size="sm" variant="outline" onClick={() => setShowPdf(true)} title="View resume">
+              <Eye size={13} />
+            </Button>
+          )}
+          {resume.fileUrl && (
+            <Button size="sm" variant="outline" onClick={handleDownload} loading={downloading} title="Download resume">
               <Download size={13} />
             </Button>
           )}
@@ -515,5 +522,21 @@ function ResumeCard({ resume, expanded, feedbackLoading, onToggleFeedback, onAiF
         </div>
       )}
     </div>
+
+    {/* PDF Viewer Modal */}
+    <Modal
+      open={showPdf}
+      onClose={() => setShowPdf(false)}
+      title={resume.fileName || resume.name || 'Resume'}
+      className="max-w-4xl"
+    >
+      <div style={{ margin: '-24px', borderRadius: '0 0 16px 16px', overflow: 'hidden' }}>
+        <iframe
+          src={resume.fileUrl}
+          style={{ width: '100%', height: '78vh', border: 'none', display: 'block' }}
+          title={resume.fileName || 'Resume'}
+        />
+      </div>
+    </Modal>
   );
 }

--- a/web/src/pages/resumes/Resumes.jsx
+++ b/web/src/pages/resumes/Resumes.jsx
@@ -530,7 +530,7 @@ function ResumeCard({ resume, expanded, feedbackLoading, onToggleFeedback, onAiF
       onClose={() => setShowPdf(false)}
       title={resume.fileName || resume.name || 'Resume'}
       className="max-w-none"
-      containerStyle={{ width: '92vw', maxHeight: '94vh' }}
+      containerStyle={{ width: '78vw', maxHeight: '92vh' }}
     >
       <div style={{ margin: '-24px', borderRadius: '0 0 16px 16px', overflow: 'hidden' }}>
         <iframe

--- a/web/src/pages/resumes/Resumes.jsx
+++ b/web/src/pages/resumes/Resumes.jsx
@@ -57,8 +57,7 @@ export default function Resumes() {
     setFeedbackLoading(prev => ({ ...prev, [resumeId]: true }));
     try {
       await api.post(`/resumes/${resumeId}/feedback`);
-      const updated = await api.get('/resumes').then(r => r.data);
-      queryClient.setQueryData(['resumes'], updated);
+      await queryClient.invalidateQueries({ queryKey: ['resumes'] });
       setExpandedFeedback(prev => ({ ...prev, [resumeId]: true }));
     } catch (err) {
       console.error('AI feedback error:', err);

--- a/web/src/pages/resumes/Resumes.jsx
+++ b/web/src/pages/resumes/Resumes.jsx
@@ -529,12 +529,13 @@ function ResumeCard({ resume, expanded, feedbackLoading, onToggleFeedback, onAiF
       open={showPdf}
       onClose={() => setShowPdf(false)}
       title={resume.fileName || resume.name || 'Resume'}
-      className="max-w-4xl"
+      className="max-w-none"
+      containerStyle={{ width: '92vw', maxHeight: '94vh' }}
     >
       <div style={{ margin: '-24px', borderRadius: '0 0 16px 16px', overflow: 'hidden' }}>
         <iframe
           src={resume.fileUrl}
-          style={{ width: '100%', height: '78vh', border: 'none', display: 'block' }}
+          style={{ width: '100%', height: '84vh', border: 'none', display: 'block' }}
           title={resume.fileName || 'Resume'}
         />
       </div>

--- a/web/src/pages/resumes/Resumes.jsx
+++ b/web/src/pages/resumes/Resumes.jsx
@@ -228,6 +228,7 @@ function ResumeCard({ resume, expanded, feedbackLoading, onToggleFeedback, onAiF
   const scoreColor = score >= 80 ? '#059669' : score >= 60 ? '#D97706' : score !== undefined ? '#DC2626' : '#9CA3AF';
 
   return (
+    <>
     <div style={{
       background: '#fff',
       border: '1px solid #E5E7EB',
@@ -538,5 +539,6 @@ function ResumeCard({ resume, expanded, feedbackLoading, onToggleFeedback, onAiF
         />
       </div>
     </Modal>
+    </>
   );
 }

--- a/web/src/pages/tasks/Tasks.jsx
+++ b/web/src/pages/tasks/Tasks.jsx
@@ -56,6 +56,7 @@ export default function Tasks() {
   const [form, setForm] = useState(emptyForm);
   const [sharedTab, setSharedTab] = useState(false);
   const [viewingTaskId, setViewingTaskId] = useState(location.state?.openTaskId ?? null);
+  const [viewingCommentId, setViewingCommentId] = useState(location.state?.commentId ?? null);
   const [showSharePicker, setShowSharePicker] = useState(false);
   const [search, setSearch] = useState('');
 
@@ -387,8 +388,9 @@ export default function Tasks() {
       <TaskDetailModal
         taskId={viewingTaskId}
         open={!!viewingTaskId}
-        onClose={() => setViewingTaskId(null)}
+        onClose={() => { setViewingTaskId(null); setViewingCommentId(null); }}
         onUpdated={invalidateTasks}
+        scrollToCommentId={viewingCommentId}
       />
 
       <ConfirmModal


### PR DESCRIPTION
## Summary
- **Registration**: Split email/username duplicate check to return specific error messages ("This email is already taken" or "This username is not available") instead of a single generic message
- **Friend search**: `avatarUrl` and `roles` were missing from the user search endpoint — profile pictures now appear when searching for friends to add
- **Resume AI feedback**: Switched from `setQueryData` to `invalidateQueries` so feedback appears immediately after generation without needing a page reload
- **Messages — badge**: Removed `VerifiedBadge` from within message group sender names (kept in the conversation header only)
- **Messages — delivery**: Removed 5-second polling from the conversation view and 8-second polling from the conversations sidebar; real-time delivery now relies entirely on Socket.io events
- **Messages — preview**: Conversation sidebar now shows "Shared a note", "Shared flashcards", or "Shared a task" instead of raw `[shared:note:69...]` strings
- **Messages — navigation**: Clicking "Message" from the Friends page now passes `conversationId` via React Router state so the conversation opens immediately instead of showing a blank screen
- **Activity feed — own actions**: Added `userId: { $ne: userId }` to the backend activity query so your own comments, likes, and shares no longer appear in your own feed (Instagram-style)
- **Activity feed — dot**: Removed the purple type-indicator dot from all activity items
- **Activity feed — shared links**: Note, flashcard set, and task titles in activity items are now clickable links that navigate directly to the shared content
- **Activity feed — likes**: `toggleLike` now emits a `like_added` socket event to the comment author so their activity feed updates instantly without a refresh

## Test Plan
- [ ] Register with an existing email → see "An account with this email already exists."
- [ ] Register with an existing username → see "This username is not available."
- [ ] Search for a friend on the Friends page → profile picture visible
- [ ] Generate AI feedback on a resume → feedback panel opens immediately
- [ ] In a conversation, verify no badge appears next to grouped sender names
- [ ] Send a message → appears instantly with no ~5s delay
- [ ] Click "Message" on an accepted friend from Friends page → conversation opens immediately, no blank screen
- [ ] In Messages sidebar, a shared-content message shows "Shared a note" (not the raw format)
- [ ] Comment on someone's post → that activity does NOT appear in your own feed
- [ ] Check Activity page — no purple dot indicator on any item
- [ ] In Activity, click a note/flashcard/task title → navigates to that content
- [ ] Like a comment → the comment author's activity feed updates without a page refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)