### PR TITLE
chore: clean launch prep — seed usernames, PostHog demo exclusion, reset script, observability docs

### DIFF
--- a/backend/controllers/auth.controller.js
+++ b/backend/controllers/auth.controller.js
@@ -456,11 +456,7 @@ exports.googleLink = async (req, res) => {
     req.user.googleTokenExpiry = new Date(Date.now() + 3600 * 1000);
     await req.user.save();
 
-    posthog.capture({
-        distinctId: req.user._id.toString(),
-        event: 'google_auth_linked',
-        properties: {},
-    });
+    posthog.capture(req.user, 'google_auth_linked');
 
     res.status(200).json({ success: true, user: req.user });
 };
@@ -928,11 +924,7 @@ exports.deleteAccount = async (req, res) => {
         });
     } catch (_) { /* non-blocking */ }
 
-    posthog.capture({
-        distinctId: userId.toString(),
-        event: 'account_deletion_requested',
-        properties: { scheduledDeletionAt: scheduledDeletionAt.toISOString() },
-    });
+    posthog.capture(req.user, 'account_deletion_requested', { scheduledDeletionAt: scheduledDeletionAt.toISOString() });
 
     res.status(200).json({ success: true, message: 'Account scheduled for deletion. Log in within 30 days to restore it.' });
 };
@@ -952,11 +944,7 @@ exports.restoreAccount = async (req, res) => {
         scheduledDeletionAt: null,
     });
 
-    posthog.capture({
-        distinctId: req.user._id.toString(),
-        event: 'account_restored',
-        properties: {},
-    });
+    posthog.capture(req.user, 'account_restored');
 
     // Re-fetch the clean user object to return
     const restored = await User.findById(req.user._id);

--- a/backend/controllers/comments.controller.js
+++ b/backend/controllers/comments.controller.js
@@ -112,15 +112,11 @@ exports.addComment = async (req, res) => {
         parentId: parentId || null,
     }).save();
 
-    posthog.capture({
-        distinctId: req.user._id.toString(),
-        event: parentId ? 'comment_reply_added' : 'comment_added',
-        properties: {
-            commentId: comment._id.toString(),
-            targetId: comment.targetId.toString(),
-            targetType: comment.targetType,
-            ...(parentId && { parentCommentId: parentId.toString() }),
-        },
+    posthog.capture(req.user, parentId ? 'comment_reply_added' : 'comment_added', {
+        commentId: comment._id.toString(),
+        targetId: comment.targetId.toString(),
+        targetType: comment.targetType,
+        ...(parentId && { parentCommentId: parentId.toString() }),
     });
 
     createActivity({

--- a/backend/controllers/flashcardSets.controller.js
+++ b/backend/controllers/flashcardSets.controller.js
@@ -55,18 +55,7 @@ exports.generateFromContent = async (req, res) => {
 
     const populatedSet = await FlashcardSet.findById(set._id).populate('flashcards');
 
-    posthog.capture({
-        distinctId: req.user._id.toString(),
-        event: 'flashcard_set_generated',
-        properties: {
-            platform: 'web',
-            set_id: set._id.toString(),
-            note_id: null,
-            source: 'text_paste',
-            card_count: result.cards.length,
-            generation_path: 'from_text_paste',
-        },
-    });
+    posthog.capture(req.user, 'flashcard_set_generated', { platform: 'web', set_id: set._id.toString(), note_id: null, source: 'text_paste', card_count: result.cards.length, generation_path: 'from_text_paste' });
 
     res.status(201).json({ success: true, set: populatedSet });
 };
@@ -183,11 +172,7 @@ exports.deleteSet = async (req, res) => {
         return res.status(404).json({ success: false, error: 'Flashcard set not found' });
     }
 
-    posthog.capture({
-        distinctId: req.user._id.toString(),
-        event: 'flashcard_set_deleted',
-        properties: { flashcardSetId: set._id.toString() },
-    });
+    posthog.capture(req.user, 'flashcard_set_deleted', { flashcardSetId: set._id.toString() });
 
     // Notify shared users so their UI removes the set without a refresh
     try {
@@ -593,24 +578,9 @@ exports.shareSet = async (req, res) => {
     }
 
     if (visibility === 'private' && existing.visibility !== 'private') {
-        posthog.capture({
-            distinctId: req.user._id.toString(),
-            event: 'flashcard_set_unshared',
-            properties: {
-                flashcardSetId: set._id.toString(),
-                previousAudience: existing.visibility,
-            },
-        });
+        posthog.capture(req.user, 'flashcard_set_unshared', { flashcardSetId: set._id.toString(), previousAudience: existing.visibility });
     } else if (visibility !== 'private') {
-        posthog.capture({
-            distinctId: req.user._id.toString(),
-            event: 'flashcard_set_shared',
-            properties: {
-                flashcardSetId: set._id.toString(),
-                audience: visibility,
-                recipientCount: visibility === 'specific' ? sharedWith.length : null,
-            },
-        });
+        posthog.capture(req.user, 'flashcard_set_shared', { flashcardSetId: set._id.toString(), audience: visibility, recipientCount: visibility === 'specific' ? sharedWith.length : null });
     }
 
     res.status(200).json({ success: true, set });

--- a/backend/controllers/friends.controller.js
+++ b/backend/controllers/friends.controller.js
@@ -115,11 +115,7 @@ exports.respondToRequest = async (req, res) => {
     await friendship.save();
 
     if (action === 'accept') {
-        posthog.capture({
-            distinctId: req.user._id.toString(),
-            event: 'friend_request_accepted',
-            properties: { friendshipId: friendship._id.toString(), fromUserId: friendship.requestedBy.toString() },
-        });
+        posthog.capture(req.user, 'friend_request_accepted', { friendshipId: friendship._id.toString(), fromUserId: friendship.requestedBy.toString() });
         try { getIO().to(`user:${friendship.requestedBy}`).emit('friend_accepted', { friendship }); } catch (_) {}
     }
 
@@ -196,11 +192,7 @@ exports.removeFriend = async (req, res) => {
         return res.status(404).json({ success: false, error: 'Friendship not found' });
     }
 
-    posthog.capture({
-        distinctId: req.user._id.toString(),
-        event: 'friend_removed',
-        properties: { friendshipId: friendship._id.toString() },
-    });
+    posthog.capture(req.user, 'friend_removed', { friendshipId: friendship._id.toString() });
 
     res.status(200).json({ success: true, message: 'Friend removed' });
 };

--- a/backend/controllers/notes.controller.js
+++ b/backend/controllers/notes.controller.js
@@ -139,11 +139,7 @@ exports.uploadNote = async (req, res) => {
         pdfPublicId: cloudinaryResult.public_id,
     });
 
-    posthog.capture({
-        distinctId: req.user._id.toString(),
-        event: 'note_created',
-        properties: { platform: 'web', source: getNoteSource(note) },
-    });
+    posthog.capture(req.user, 'note_created', { platform: 'web', source: getNoteSource(note) });
 
     res.status(201).json({ success: true, note });
 };
@@ -200,11 +196,7 @@ exports.createNote = async (req, res) => {
         visibility,
     });
 
-    posthog.capture({
-        distinctId: req.user._id.toString(),
-        event: 'note_created',
-        properties: { platform: 'web', source: getNoteSource(note) },
-    });
+    posthog.capture(req.user, 'note_created', { platform: 'web', source: getNoteSource(note) });
 
     res.status(201).json({ success: true, note });
 };
@@ -359,11 +351,7 @@ exports.deleteNote = async (req, res) => {
         return res.status(404).json({ success: false, error: 'Note not found' });
     }
 
-    posthog.capture({
-        distinctId: req.user._id.toString(),
-        event: 'note_deleted',
-        properties: { noteId: note._id.toString() },
-    });
+    posthog.capture(req.user, 'note_deleted', { noteId: note._id.toString() });
 
     // Notify shared users so their UI removes the note without a refresh
     try {
@@ -437,17 +425,9 @@ exports.importNote = async (req, res) => {
         lastViewedAt: new Date(), // ensures new import sorts to top (list sorts by lastViewedAt desc)
     });
 
-    posthog.capture({
-        distinctId: req.user._id.toString(),
-        event: 'note_created',
-        properties: { platform: 'web', source: getNoteSource(note) },
-    });
+    posthog.capture(req.user, 'note_created', { platform: 'web', source: getNoteSource(note) });
 
-    posthog.capture({
-        distinctId: req.user._id.toString(),
-        event: 'google_doc_imported',
-        properties: { noteId: note._id.toString() },
-    });
+    posthog.capture(req.user, 'google_doc_imported', { noteId: note._id.toString() });
 
     res.status(201).json({ success: true, note });
 };
@@ -554,16 +534,7 @@ exports.generateSummary = async (req, res) => {
     // Summary is fast — always run synchronously for instant UX
     const result = await groqService.generateSummary(note.content, req.user._id);
 
-    posthog.capture({
-        distinctId: req.user._id.toString(),
-        event: 'note_summary_generated',
-        properties: {
-            platform: 'web',
-            note_id: note._id.toString(),
-            source: getNoteSource(note),
-            note_type: note.type,
-        },
-    });
+    posthog.capture(req.user, 'note_summary_generated', { platform: 'web', note_id: note._id.toString(), source: getNoteSource(note), note_type: note.type });
 
     if (isOwner) {
         const updatedNote = await Note.findByIdAndUpdate(
@@ -657,18 +628,7 @@ exports.generateFlashcardsFromNote = async (req, res) => {
 
     const populatedSet = await FlashcardSet.findById(set._id).populate('flashcards');
 
-    posthog.capture({
-        distinctId: req.user._id.toString(),
-        event: 'flashcard_set_generated',
-        properties: {
-            platform: 'web',
-            set_id: set._id.toString(),
-            note_id: note._id.toString(),
-            source: getNoteSource(note),
-            card_count: result.cards.length,
-            generation_path: 'from_note',
-        },
-    });
+    posthog.capture(req.user, 'flashcard_set_generated', { platform: 'web', set_id: set._id.toString(), note_id: note._id.toString(), source: getNoteSource(note), card_count: result.cards.length, generation_path: 'from_note' });
 
     res.status(201).json({ success: true, set: populatedSet });
 };
@@ -785,24 +745,9 @@ exports.shareNote = async (req, res) => {
     }
 
     if (visibility === 'private' && existing.visibility !== 'private') {
-        posthog.capture({
-            distinctId: req.user._id.toString(),
-            event: 'note_unshared',
-            properties: {
-                noteId: note._id.toString(),
-                previousAudience: existing.visibility,
-            },
-        });
+        posthog.capture(req.user, 'note_unshared', { noteId: note._id.toString(), previousAudience: existing.visibility });
     } else if (visibility !== 'private') {
-        posthog.capture({
-            distinctId: req.user._id.toString(),
-            event: 'note_shared',
-            properties: {
-                noteId: note._id.toString(),
-                audience: visibility,
-                recipientCount: visibility === 'specific' ? sharedWith.length : null,
-            },
-        });
+        posthog.capture(req.user, 'note_shared', { noteId: note._id.toString(), audience: visibility, recipientCount: visibility === 'specific' ? sharedWith.length : null });
     }
 
     res.status(200).json({ success: true, note });

--- a/backend/controllers/resumes.controller.js
+++ b/backend/controllers/resumes.controller.js
@@ -175,14 +175,7 @@ exports.generateFeedback = async (req, res) => {
         { new: true }
     );
 
-    posthog.capture({
-        distinctId: req.user._id.toString(),
-        event: 'resume_feedback_generated',
-        properties: {
-            platform: 'web',
-            resume_id: resume._id.toString(),
-        },
-    });
+    posthog.capture(req.user, 'resume_feedback_generated', { platform: 'web', resume_id: resume._id.toString() });
 
     res.status(200).json({ success: true, feedback: updated.feedback[updated.feedback.length - 1], resume: updated });
 };

--- a/backend/controllers/studySessions.controller.js
+++ b/backend/controllers/studySessions.controller.js
@@ -118,15 +118,7 @@ exports.submitSession = async (req, res) => {
         // Socket not critical — swallow errors
     }
 
-    posthog.capture({
-        distinctId: userId,
-        event: 'study_session_completed',
-        properties: {
-            platform: 'web',
-            session_id: session._id.toString(),
-            set_id: setId.toString(),
-        },
-    });
+    posthog.capture(req.user, 'study_session_completed', { platform: 'web', session_id: session._id.toString(), set_id: setId.toString() });
 
     res.status(201).json({ success: true, session, streak });
 };

--- a/backend/controllers/tasks.controller.js
+++ b/backend/controllers/tasks.controller.js
@@ -108,14 +108,7 @@ exports.createTask = async (req, res) => {
     });
 
     if (task.isShared && validatedParticipants.length > 0) {
-        posthog.capture({
-            distinctId: req.user._id.toString(),
-            event: 'task_shared',
-            properties: {
-                taskId: task._id.toString(),
-                recipientCount: validatedParticipants.length,
-            },
-        });
+        posthog.capture(req.user, 'task_shared', { taskId: task._id.toString(), recipientCount: validatedParticipants.length });
 
         createShareActivities({
             actorId: req.user._id,

--- a/backend/lib/posthog.js
+++ b/backend/lib/posthog.js
@@ -15,5 +15,15 @@ process.on('beforeExit', async () => {
 // Falls back to APP_VERSION if set manually, then 'unknown' locally.
 const appVersion = process.env.RENDER_GIT_COMMIT ?? process.env.APP_VERSION ?? 'unknown'
 
-module.exports = client
-module.exports.appVersion = appVersion
+// Wrapper that silences all events for demo and seed accounts.
+// Usage: posthog.capture(req.user, 'event_name', { ...props })
+function capture(user, event, properties = {}) {
+  if (!user || user.isDemo || user.isSeedUser) return
+  client.capture({
+    distinctId: user._id.toString(),
+    event,
+    properties: { ...properties, appVersion },
+  })
+}
+
+module.exports = { capture, client, appVersion }

--- a/backend/scripts/reset-prod.js
+++ b/backend/scripts/reset-prod.js
@@ -1,0 +1,100 @@
+// =============================================================================
+// reset-prod.js — Drop all user-generated collections for a clean launch
+// =============================================================================
+//
+// Usage:
+//   node backend/scripts/reset-prod.js
+//
+// Reads MONGODB_URI from backend/.env (same as the seed scripts).
+// To target prod: set MONGODB_URI in backend/.env to your Atlas prod URI.
+// To target test: set MONGODB_URI to your test URI.
+//
+// After running, re-seed with:
+//   node backend/scripts/seed-jane.js
+//   node backend/scripts/seed-justin.js
+// =============================================================================
+
+require('dotenv').config({ path: require('path').join(__dirname, '../.env') });
+const mongoose = require('mongoose');
+const readline = require('readline');
+
+const COLLECTIONS = [
+  'users',
+  'notes',
+  'flashcardsets',
+  'flashcards',
+  'tasks',
+  'applications',
+  'friendships',
+  'conversations',
+  'messages',
+  'comments',
+  'activities',
+  'studysessions',
+  'resumes',
+  'sessions',
+  'refreshtokens',
+  'oauthcodes',
+  'syncqueues',
+  'waitlists',
+];
+
+async function confirm(question) {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  return new Promise((resolve) => {
+    rl.question(question, (answer) => {
+      rl.close();
+      resolve(answer.trim());
+    });
+  });
+}
+
+async function main() {
+  const uri = process.env.MONGODB_URI;
+  if (!uri) {
+    console.error('Error: MONGODB_URI not set in backend/.env');
+    process.exit(1);
+  }
+
+  // Show the target database so you know exactly what will be wiped
+  const dbName = uri.split('/').pop().split('?')[0];
+  console.log('\n⚠️  Target database:', dbName);
+  console.log('⚠️  URI:', uri.replace(/:([^:@]+)@/, ':****@'));
+  console.log('\nCollections to drop:');
+  COLLECTIONS.forEach((c) => console.log('  -', c));
+
+  const answer = await confirm('\nType RESET to confirm dropping all collections: ');
+  if (answer !== 'RESET') {
+    console.log('Aborted.');
+    process.exit(0);
+  }
+
+  await mongoose.connect(uri);
+  console.log('\nConnected to MongoDB. Dropping collections...\n');
+
+  const db = mongoose.connection.db;
+
+  for (const name of COLLECTIONS) {
+    const collection = db.collection(name);
+    const count = await collection.countDocuments();
+    if (count === 0) {
+      console.log(`  ${name}: empty, skipping`);
+      continue;
+    }
+    await collection.drop().catch(() => {});
+    console.log(`  ${name}: dropped (${count} documents removed)`);
+  }
+
+  console.log('\nDone. Database is clean.');
+  console.log('\nNext steps:');
+  console.log('  node backend/scripts/seed-jane.js');
+  console.log('  node backend/scripts/seed-justin.js');
+
+  await mongoose.disconnect();
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error('Error:', err.message);
+  process.exit(1);
+});

--- a/backend/scripts/seed-jane.js
+++ b/backend/scripts/seed-jane.js
@@ -25,33 +25,33 @@ const CLEAN = process.argv.includes('--clean');
 
 // ─── Jane's 20 friends (promoted from SEED_STRANGERS) ──────────────────────
 const JANE_FRIEND_USERNAMES = [
-  'carolinehall', 'chrisnguyen', 'connorflynn', 'dianachen', 'ethancooper',
-  'evawong', 'graciecallahan', 'isabellachang', 'jadewashington', 'jasonmendez',
-  'kevinzhang', 'kiananderson', 'logancarter', 'michaelrobbins', 'noahcoleman',
-  'rachelmontgomery', 'ryanfoster', 'taylormorgan', 'trevornash', 'zoeanderson',
+  'carolinehall_demo', 'chrisnguyen_demo', 'connorflynn_demo', 'dianachen_demo', 'ethancooper_demo',
+  'evawong_demo', 'graciecallahan_demo', 'isabellachang_demo', 'jadewashington_demo', 'jasonmendez_demo',
+  'kevinzhang_demo', 'kiananderson_demo', 'logancarter_demo', 'michaelrobbins_demo', 'noahcoleman_demo',
+  'rachelmontgomery_demo', 'ryanfoster_demo', 'taylormorgan_demo', 'trevornash_demo', 'zoeanderson_demo',
 ];
 
 const FRIEND_NAMES = {
-  carolinehall:    { firstName: 'Caroline',  lastName: 'Hall' },
-  chrisnguyen:     { firstName: 'Chris',     lastName: 'Nguyen' },
-  connorflynn:     { firstName: 'Connor',    lastName: 'Flynn' },
-  dianachen:       { firstName: 'Diana',     lastName: 'Chen' },
-  ethancooper:     { firstName: 'Ethan',     lastName: 'Cooper' },
-  evawong:         { firstName: 'Eva',       lastName: 'Wong' },
-  graciecallahan:  { firstName: 'Gracie',    lastName: 'Callahan' },
-  isabellachang:   { firstName: 'Isabella',  lastName: 'Chang' },
-  jadewashington:  { firstName: 'Jade',      lastName: 'Washington' },
-  jasonmendez:     { firstName: 'Jason',     lastName: 'Mendez' },
-  kevinzhang:      { firstName: 'Kevin',     lastName: 'Zhang' },
-  kiananderson:    { firstName: 'Kian',      lastName: 'Anderson' },
-  logancarter:     { firstName: 'Logan',     lastName: 'Carter' },
-  michaelrobbins:  { firstName: 'Michael',   lastName: 'Robbins' },
-  noahcoleman:     { firstName: 'Noah',      lastName: 'Coleman' },
-  rachelmontgomery:{ firstName: 'Rachel',    lastName: 'Montgomery' },
-  ryanfoster:      { firstName: 'Ryan',      lastName: 'Foster' },
-  taylormorgan:    { firstName: 'Taylor',    lastName: 'Morgan' },
-  trevornash:      { firstName: 'Trevor',    lastName: 'Nash' },
-  zoeanderson:     { firstName: 'Zoe',       lastName: 'Anderson' },
+  carolinehall_demo:    { firstName: 'Caroline',  lastName: 'Hall' },
+  chrisnguyen_demo:     { firstName: 'Chris',     lastName: 'Nguyen' },
+  connorflynn_demo:     { firstName: 'Connor',    lastName: 'Flynn' },
+  dianachen_demo:       { firstName: 'Diana',     lastName: 'Chen' },
+  ethancooper_demo:     { firstName: 'Ethan',     lastName: 'Cooper' },
+  evawong_demo:         { firstName: 'Eva',       lastName: 'Wong' },
+  graciecallahan_demo:  { firstName: 'Gracie',    lastName: 'Callahan' },
+  isabellachang_demo:   { firstName: 'Isabella',  lastName: 'Chang' },
+  jadewashington_demo:  { firstName: 'Jade',      lastName: 'Washington' },
+  jasonmendez_demo:     { firstName: 'Jason',     lastName: 'Mendez' },
+  kevinzhang_demo:      { firstName: 'Kevin',     lastName: 'Zhang' },
+  kiananderson_demo:    { firstName: 'Kian',      lastName: 'Anderson' },
+  logancarter_demo:     { firstName: 'Logan',     lastName: 'Carter' },
+  michaelrobbins_demo:  { firstName: 'Michael',   lastName: 'Robbins' },
+  noahcoleman_demo:     { firstName: 'Noah',      lastName: 'Coleman' },
+  rachelmontgomery_demo:{ firstName: 'Rachel',    lastName: 'Montgomery' },
+  ryanfoster_demo:      { firstName: 'Ryan',      lastName: 'Foster' },
+  taylormorgan_demo:    { firstName: 'Taylor',    lastName: 'Morgan' },
+  trevornash_demo:      { firstName: 'Trevor',    lastName: 'Nash' },
+  zoeanderson_demo:     { firstName: 'Zoe',       lastName: 'Anderson' },
 };
 
 // ─── Clean ───────────────────────────────────────────────────────────────────
@@ -104,7 +104,11 @@ async function cleanJaneData(janeId) {
   });
 
   // Friend content (shared notes, flashcard sets, shared tasks seeded for Jane's friends)
-  const friendUsers = await User.find({ username: { $in: JANE_FRIEND_USERNAMES } }).select('_id');
+  // Search by email too — handles migration from pre-rename usernames (e.g. 'carolinehall' → 'carolinehall_demo')
+  const friendEmails = JANE_FRIEND_USERNAMES.map(u => `${u}@example.com`);
+  const friendUsers = await User.find({
+    $or: [{ username: { $in: JANE_FRIEND_USERNAMES } }, { email: { $in: friendEmails } }],
+  }).select('_id');
   const friendIds = friendUsers.map(f => f._id);
   if (friendIds.length) {
     const friendSets = await FlashcardSet.find({ userId: { $in: friendIds } }).select('_id');
@@ -125,10 +129,10 @@ async function cleanJaneData(janeId) {
 
 async function createJane() {
   console.log('Creating Jane Doe...');
-  let jane = await User.findOne({ username: 'janedoe' });
+  let jane = await User.findOne({ email: 'janedoe_demo@example.com' });
   if (!jane) {
     jane = new User({
-      username: 'janedoe',
+      username: 'janedoe_demo',
       email: 'janedoe_demo@example.com',
       password: 'Demo@1234',
       firstName: 'Jane',
@@ -154,13 +158,18 @@ async function seedFriends(jane) {
   const friends = [];
 
   for (const username of JANE_FRIEND_USERNAMES) {
-    let user = await User.findOne({ username });
+    const email = `${username}@example.com`;
+    let user = await User.findOne({ $or: [{ username }, { email }] });
+    if (user && user.username !== username) {
+      user.username = username;
+      await user.save();
+    }
     if (!user) {
       // Friend hasn't been seeded yet — create with isSeedUser flag
       const names = FRIEND_NAMES[username] || { firstName: username, lastName: 'Demo' };
       user = new User({
         username,
-        email: `${username}_demo@example.com`,
+        email,
         password: 'Demo@1234',
         firstName: names.firstName,
         lastName: names.lastName,
@@ -1007,8 +1016,8 @@ async function main() {
     await mongoose.connect(mongoUri);
     console.log('Connected to MongoDB');
 
-    // Idempotency check
-    const existing = await User.findOne({ username: 'janedoe' });
+    // Idempotency check — match by email to handle migration from old 'janedoe' username
+    const existing = await User.findOne({ email: 'janedoe_demo@example.com' });
     if (existing && !CLEAN) {
       console.log('Jane Doe already exists. Use --clean to reseed.');
       process.exit(0);
@@ -1075,6 +1084,7 @@ async function main() {
     process.exit(1);
   } finally {
     await mongoose.disconnect();
+    process.exit(0);
   }
 }
 

--- a/backend/scripts/seed-justin.js
+++ b/backend/scripts/seed-justin.js
@@ -43,7 +43,7 @@ const SEED_FRIENDS = [
     settings: { activityVisibility: 'friends' },
   },
   {
-    username: 'jordanwilliams',
+    username: 'jordanwilliams_demo',
     email: 'jordanwilliams_demo@example.com',
     password: 'Demo@1234',
     firstName: 'Jordan',
@@ -52,7 +52,7 @@ const SEED_FRIENDS = [
     settings: { activityVisibility: 'friends' },
   },
   {
-    username: 'priyasharma',
+    username: 'priyasharma_demo',
     email: 'priyasharma_demo@example.com',
     password: 'Demo@1234',
     firstName: 'Priya',
@@ -61,7 +61,7 @@ const SEED_FRIENDS = [
     settings: { activityVisibility: 'friends' },
   },
   {
-    username: 'marcusjohnson',
+    username: 'marcusjohnson_demo',
     email: 'marcusjohnson_demo@example.com',
     password: 'Demo@1234',
     firstName: 'Marcus',
@@ -70,7 +70,7 @@ const SEED_FRIENDS = [
     settings: { activityVisibility: 'friends' },
   },
   {
-    username: 'sofiarod',
+    username: 'sofiarod_demo',
     email: 'sofiarod_demo@example.com',
     password: 'Demo@1234',
     firstName: 'Sofia',
@@ -85,137 +85,137 @@ const SEED_USERNAMES = SEED_FRIENDS.map(f => f.username);
 // ─── Non-Friend Users (searchable, no friendship with Justin) ────────────────
 
 const SEED_STRANGERS = [
-  { username: 'aaronmitchell', firstName: 'Aaron', lastName: 'Mitchell', bio: 'CS junior into cybersecurity and CTF competitions. Trying to break into bug bounty.' },
-  { username: 'abbygrant', firstName: 'Abby', lastName: 'Grant', bio: 'English lit senior writing her thesis on postcolonial fiction. Coffee shop regular.' },
-  { username: 'adrianreyes', firstName: 'Adrian', lastName: 'Reyes', bio: 'Mechanical engineering junior. Formula SAE team lead. Loves CAD and motorsport.' },
-  { username: 'alanawhite', firstName: 'Alana', lastName: 'White', bio: 'Public health sophomore. Interested in global health policy and epidemiology.' },
-  { username: 'alexisford', firstName: 'Alexis', lastName: 'Ford', bio: 'Accounting junior with a minor in data analytics. CPA prep starts next year.' },
-  { username: 'aliciamoreno', firstName: 'Alicia', lastName: 'Moreno', bio: 'Architecture student designing sustainable housing. Studio life is real.' },
-  { username: 'allisonbell', firstName: 'Allison', lastName: 'Bell', bio: 'Music performance major and part-time piano teacher. Classical meets jazz.' },
-  { username: 'amandalee', firstName: 'Amanda', lastName: 'Lee', bio: 'Pre-law junior. Mock trial president. Interested in intellectual property law.' },
-  { username: 'amirahassan', firstName: 'Amira', lastName: 'Hassan', bio: 'Neuroscience sophomore. Lab assistant studying memory consolidation.' },
-  { username: 'andrewkim', firstName: 'Andrew', lastName: 'Kim', bio: 'Software engineering senior with a backend focus. Interning at a startup this summer.' },
-  { username: 'angelapark', firstName: 'Angela', lastName: 'Park', bio: 'Marketing major obsessed with brand strategy and social media analytics.' },
-  { username: 'anthonygreen', firstName: 'Anthony', lastName: 'Green', bio: 'Econ major with a quant focus. Interested in hedge funds and algorithmic trading.' },
-  { username: 'aryankapoor', firstName: 'Aryan', lastName: 'Kapoor', bio: 'Data engineering junior. Loves Spark, Kafka, and building data pipelines at scale.' },
-  { username: 'ashleythomas', firstName: 'Ashley', lastName: 'Thomas', bio: 'Kinesiology senior studying sports performance. Training for her first triathlon.' },
-  { username: 'austinwalker', firstName: 'Austin', lastName: 'Walker', bio: 'Game dev enthusiast. Unity and Unreal projects in progress. Indie dev dreams.' },
-  { username: 'averyharris', firstName: 'Avery', lastName: 'Harris', bio: 'Biology sophomore on the pre-vet track. Currently studying for the GRE.' },
-  { username: 'ayeshazahid', firstName: 'Ayesha', lastName: 'Zahid', bio: 'Chemical engineering junior. Research in polymer synthesis and sustainable materials.' },
-  { username: 'baileyrogers', firstName: 'Bailey', lastName: 'Rogers', bio: 'Political science senior interning on a state senator campaign.' },
-  { username: 'benswanson', firstName: 'Ben', lastName: 'Swanson', bio: 'Stats and CS double major. Applying for quant research roles. Kaggle competitor.' },
-  { username: 'brettjohnson', firstName: 'Brett', lastName: 'Johnson', bio: 'Finance junior on the investment club board. DCF and comps all day.' },
-  { username: 'brittanycox', firstName: 'Brittany', lastName: 'Cox', bio: 'Communications major and campus newspaper editor. Aspiring journalist.' },
-  { username: 'camelolivier', firstName: 'Camel', lastName: 'Olivier', bio: 'International relations junior. Studied abroad in Paris last semester. Fluent in French.' },
-  { username: 'carlosfernandez', firstName: 'Carlos', lastName: 'Fernandez', bio: 'Electrical engineering senior specializing in signal processing and embedded systems.' },
-  { username: 'carolinehall', firstName: 'Caroline', lastName: 'Hall', bio: 'Graphic design junior building her portfolio. UI/UX freelance work on the side.' },
-  { username: 'cassandralewis', firstName: 'Cassandra', lastName: 'Lewis', bio: 'Sociology senior studying urban inequality and housing policy.' },
-  { username: 'chandlerdavis', firstName: 'Chandler', lastName: 'Davis', bio: 'Supply chain management junior with internship at a logistics company.' },
-  { username: 'charlottehill', firstName: 'Charlotte', lastName: 'Hill', bio: 'Environmental science sophomore. Research on microplastics in freshwater systems.' },
-  { username: 'chrisnguyen', firstName: 'Chris', lastName: 'Nguyen', bio: 'CS and math double major. Exploring formal verification and type theory.' },
-  { username: 'christinabaker', firstName: 'Christina', lastName: 'Baker', bio: 'Nursing junior. Clinical rotations start in the fall. Future ICU nurse.' },
-  { username: 'claudiavega', firstName: 'Claudia', lastName: 'Vega', bio: 'Psychology senior running a study on social media and anxiety in college students.' },
-  { username: 'connorflynn', firstName: 'Connor', lastName: 'Flynn', bio: 'Philosophy and CS double major. Interested in AI ethics and philosophy of mind.' },
-  { username: 'coopermartin', firstName: 'Cooper', lastName: 'Martin', bio: 'Aerospace engineering junior. Rocketry club president. SpaceX internship goal.' },
-  { username: 'coreystone', firstName: 'Corey', lastName: 'Stone', bio: 'Business analytics junior. Python for finance, Tableau dashboards, Excel power user.' },
-  { username: 'daniellebrown', firstName: 'Danielle', lastName: 'Brown', bio: 'Creative writing MFA. Short stories published in two literary journals this year.' },
-  { username: 'davidwilson', firstName: 'David', lastName: 'Wilson', bio: 'Mechanical engineering senior with a robotics specialization. ROS and SLAM all day.' },
-  { username: 'demi_okonkwo', firstName: 'Demi', lastName: 'Okonkwo', bio: 'Pre-med senior. MCAT score: 518. Applying to MD/PhD programs this cycle.' },
-  { username: 'derek_santos', firstName: 'Derek', lastName: 'Santos', bio: 'Sports management junior. Working on a thesis about NIL deals in college athletics.' },
-  { username: 'dianachen', firstName: 'Diana', lastName: 'Chen', bio: 'Biochem and CS double major. Computational drug discovery research assistant.' },
-  { username: 'dominicross', firstName: 'Dominic', lastName: 'Ross', bio: 'Economics senior writing on cryptocurrency adoption in emerging markets.' },
-  { username: 'dylanmurphy', firstName: 'Dylan', lastName: 'Murphy', bio: 'Computer science sophomore. Just finished my first internship at a SaaS company.' },
-  { username: 'emilyharrison', firstName: 'Emily', lastName: 'Harrison', bio: 'Art history junior with a minor in museum studies. Interning at a local gallery.' },
-  { username: 'ericrogers', firstName: 'Eric', lastName: 'Rogers', bio: 'Physics senior doing undergraduate research in quantum optics lab.' },
-  { username: 'erikamorales', firstName: 'Erika', lastName: 'Morales', bio: 'Industrial engineering junior. Passionate about lean manufacturing and operations research.' },
-  { username: 'ethancooper', firstName: 'Ethan', lastName: 'Cooper', bio: 'CS junior specializing in NLP. Built a sentiment analysis tool for course reviews.' },
-  { username: 'evawong', firstName: 'Eva', lastName: 'Wong', bio: 'Health informatics senior. Bridging EHR data and ML for clinical decision support.' },
-  { username: 'faithturner', firstName: 'Faith', lastName: 'Turner', bio: 'Education major. Student teaching this semester. Passionate about math pedagogy.' },
-  { username: 'fionasmith', firstName: 'Fiona', lastName: 'Smith', bio: 'Environmental studies junior. Campus sustainability committee co-chair.' },
-  { username: 'gabriellalopez', firstName: 'Gabriella', lastName: 'Lopez', bio: 'Theater performance major and improv team captain. Also fluent in Spanish.' },
-  { username: 'garretthughes', firstName: 'Garrett', lastName: 'Hughes', bio: 'Finance and accounting double major. Passed CFA Level I last December.' },
-  { username: 'gemmaoverton', firstName: 'Gemma', lastName: 'Overton', bio: 'Biology junior with a focus on genetics. CRISPR research assistant.' },
-  { username: 'grantpayne', firstName: 'Grant', lastName: 'Payne', bio: 'Management information systems senior. SAP certification in progress.' },
-  { username: 'graciecallahan', firstName: 'Gracie', lastName: 'Callahan', bio: 'Social work junior. Volunteer crisis counselor. Mental health advocacy on campus.' },
-  { username: 'hannahwebb', firstName: 'Hannah', lastName: 'Webb', bio: 'Journalism and political science double major. Campus radio host.' },
-  { username: 'harperscott', firstName: 'Harper', lastName: 'Scott', bio: 'Marketing junior focusing on brand strategy. Founder of a small Etsy shop.' },
-  { username: 'henryfields', firstName: 'Henry', lastName: 'Fields', bio: 'History and economics double major. Writing a thesis on the 2008 financial crisis.' },
-  { username: 'isabellachang', firstName: 'Isabella', lastName: 'Chang', bio: 'CS sophomore interested in full-stack development. Built 3 projects this semester.' },
-  { username: 'ivannazaro', firstName: 'Ivan', lastName: 'Nazaro', bio: 'Materials science and engineering senior. Research in solid-state batteries.' },
-  { username: 'jadewashington', firstName: 'Jade', lastName: 'Washington', bio: "Criminal justice junior. Internship with a public defender's office this summer." },
-  { username: 'jakeoliver', firstName: 'Jake', lastName: 'Oliver', bio: 'Accounting senior. Big Four internship lined up. Loves golf and tax law trivia.' },
-  { username: 'jasmineyoung', firstName: 'Jasmine', lastName: 'Young', bio: 'Pre-pharmacy junior. Completing 300 hours of pharmacy observation this year.' },
-  { username: 'jasonmendez', firstName: 'Jason', lastName: 'Mendez', bio: 'Civil engineering senior. Structural analysis and bridge design competition winner.' },
-  { username: 'jaydennelson', firstName: 'Jayden', lastName: 'Nelson', bio: 'Sports science and exercise physiology major. Strength and conditioning coach.' },
-  { username: 'jessicaadams', firstName: 'Jessica', lastName: 'Adams', bio: 'Psychology and statistics double major. Running logistic regression on clinical data.' },
-  { username: 'jonathanreeves', firstName: 'Jonathan', lastName: 'Reeves', bio: 'Computer engineering junior. FPGA design and embedded Linux enthusiast.' },
-  { username: 'juliacosta', firstName: 'Julia', lastName: 'Costa', bio: 'International business junior with a semester abroad in São Paulo.' },
-  { username: 'justinstewart', firstName: 'Justin', lastName: 'Stewart', bio: 'CS sophomore. Currently grinding LeetCode and looking for internships.' },
-  { username: 'kaileyjones', firstName: 'Kailey', lastName: 'Jones', bio: 'Elementary education major. Student teaching at Lincoln Elementary this fall.' },
-  { username: 'karenshaw', firstName: 'Karen', lastName: 'Shaw', bio: 'Food science and nutrition junior. Research on gut microbiome and cognitive health.' },
-  { username: 'karlmorrison', firstName: 'Karl', lastName: 'Morrison', bio: 'Philosophy junior wrestling with ethics of autonomous systems and AI.' },
-  { username: 'katelyn_price', firstName: 'Katelyn', lastName: 'Price', bio: 'Marketing and design double major. Brand consulting side hustle.' },
-  { username: 'keirajohnston', firstName: 'Keira', lastName: 'Johnston', bio: 'Biology senior heading to medical school in the fall. Pediatrics interest.' },
-  { username: 'kevinzhang', firstName: 'Kevin', lastName: 'Zhang', bio: 'ML engineer track. PyTorch, transformers, and fine-tuning LLMs for fun.' },
-  { username: 'kiananderson', firstName: 'Kian', lastName: 'Anderson', bio: 'Human-computer interaction junior. Obsessed with accessibility and inclusive design.' },
-  { username: 'kristinawills', firstName: 'Kristina', lastName: 'Wills', bio: 'Communications and PR major. Runs the campus events Instagram page.' },
-  { username: 'kylewatson', firstName: 'Kyle', lastName: 'Watson', bio: 'Civil and environmental engineering senior. Capstone: stormwater management system.' },
-  { username: 'laurencollins', firstName: 'Lauren', lastName: 'Collins', bio: 'Human resources management junior. SHRM certification prep in progress.' },
-  { username: 'leahowens', firstName: 'Leah', lastName: 'Owens', bio: 'Chemistry sophomore doing undergraduate research in organometallics.' },
-  { username: 'lewisbishop', firstName: 'Lewis', lastName: 'Bishop', bio: 'Economics and philosophy double major. Writing about behavioral nudges in policy.' },
-  { username: 'lilymcgee', firstName: 'Lily', lastName: 'McGee', bio: 'Graphic design senior with a portfolio in editorial illustration and branding.' },
-  { username: 'linaberger', firstName: 'Lina', lastName: 'Berger', bio: 'German and international relations double major. Exchange student program coordinator.' },
-  { username: 'logancarter', firstName: 'Logan', lastName: 'Carter', bio: 'CS junior doing research on distributed systems and consensus algorithms.' },
-  { username: 'luisaguerra', firstName: 'Luisa', lastName: 'Guerra', bio: 'Public relations junior. Campus newspaper features editor. Aspiring media strategist.' },
-  { username: 'lukethompson', firstName: 'Luke', lastName: 'Thompson', bio: 'Athletic training junior. Working with the football team as a student trainer.' },
-  { username: 'madisonperkins', firstName: 'Madison', lastName: 'Perkins', bio: 'Sociology and criminology double major. Research on recidivism and prison reform.' },
-  { username: 'marcohernandez', firstName: 'Marco', lastName: 'Hernandez', bio: 'Information systems senior. Specializing in ERP implementation and IT consulting.' },
-  { username: 'marissaward', firstName: 'Marissa', lastName: 'Ward', bio: 'Nursing junior completing clinical hours at the county hospital. ICU focus.' },
-  { username: 'matthewevans', firstName: 'Matthew', lastName: 'Evans', bio: 'CS and linguistics double major. NLP research on code-switching in bilingual texts.' },
-  { username: 'meganlewis', firstName: 'Megan', lastName: 'Lewis', bio: 'Finance junior with an internship at a regional bank. CFA prep in progress.' },
-  { username: 'melissacruz', firstName: 'Melissa', lastName: 'Cruz', bio: 'Healthcare management junior. Interning at a hospital administration office.' },
-  { username: 'michaelrobbins', firstName: 'Michael', lastName: 'Robbins', bio: 'Physics and CS double major. Applying for PhD programs in quantum computing.' },
-  { username: 'migueltorres', firstName: 'Miguel', lastName: 'Torres', bio: 'Mechanical engineering junior. Renewable energy focus. Solar car team captain.' },
-  { username: 'morgandixon', firstName: 'Morgan', lastName: 'Dixon', bio: 'Psychology and data science double major. Running sentiment analysis on therapy transcripts.' },
-  { username: 'naomirichards', firstName: 'Naomi', lastName: 'Richards', bio: 'Pre-med senior with a research background in infectious disease and immunology.' },
-  { username: 'nathanielbrown', firstName: 'Nathaniel', lastName: 'Brown', bio: 'CS sophomore learning systems programming in Rust. OS project in progress.' },
-  { username: 'nicolassimon', firstName: 'Nicolas', lastName: 'Simon', bio: 'International economics junior. Thesis on trade policy post-COVID.' },
-  { username: 'nicolewagner', firstName: 'Nicole', lastName: 'Wagner', bio: 'Biology and chemistry double major on the pre-pharmacy track.' },
-  { username: 'noahcoleman', firstName: 'Noah', lastName: 'Coleman', bio: 'CS junior focused on computer vision. Working on a real-time pose estimation project.' },
-  { username: 'oliviachang', firstName: 'Olivia', lastName: 'Chang', bio: 'Biomedical engineering sophomore. Research in drug delivery systems.' },
-  { username: 'owenparker', firstName: 'Owen', lastName: 'Parker', bio: 'Political science and communications double major. Student government vice president.' },
-  { username: 'paigethornton', firstName: 'Paige', lastName: 'Thornton', bio: 'Fashion merchandising junior. Runs a sustainable fashion blog with 5k followers.' },
-  { username: 'patrickhughes', firstName: 'Patrick', lastName: 'Hughes', bio: 'Finance senior with a CFA Level I. Aiming for equity research at a bulge bracket.' },
-  { username: 'paulavargas', firstName: 'Paula', lastName: 'Vargas', bio: 'Biochemistry senior heading to a PhD in pharmacology. Enzyme kinetics researcher.' },
-  { username: 'philippedumont', firstName: 'Philippe', lastName: 'Dumont', bio: 'French and economics double major. Exchange student from Lyon on a one-year program.' },
-  { username: 'rachelmontgomery', firstName: 'Rachel', lastName: 'Montgomery', bio: 'Psychology junior doing research on trauma and cognitive behavioral therapy.' },
-  { username: 'ryanfoster', firstName: 'Ryan', lastName: 'Foster', bio: 'Computer science junior. Competitive programmer, top 5% on Codeforces.' },
-  { username: 'samaraellis', firstName: 'Samara', lastName: 'Ellis', bio: 'Digital marketing and analytics senior. Google Analytics certified.' },
-  { username: 'samuelwhite', firstName: 'Samuel', lastName: 'White', bio: 'Operations research junior using optimization models for supply chain problems.' },
-  { username: 'sarahcampbell', firstName: 'Sarah', lastName: 'Campbell', bio: 'Biostatistics senior applying for epidemiology PhD programs. R and Stata daily.' },
-  { username: 'scottmanning', firstName: 'Scott', lastName: 'Manning', bio: 'History junior specializing in Cold War and US foreign policy.' },
-  { username: 'sierrarobinson', firstName: 'Sierra', lastName: 'Robinson', bio: 'Environmental engineering junior. Capstone: air quality modeling for urban areas.' },
-  { username: 'stephaniegrant', firstName: 'Stephanie', lastName: 'Grant', bio: 'Accounting and information systems double major. ERP systems internship this summer.' },
-  { username: 'tannerwood', firstName: 'Tanner', lastName: 'Wood', bio: 'Finance junior. Investment club treasurer. Day trading on the side.' },
-  { username: 'taylormorgan', firstName: 'Taylor', lastName: 'Morgan', bio: 'CS and graphic design double major. Building a design system for a startup.' },
-  { username: 'tianarobinson', firstName: 'Tiana', lastName: 'Robinson', bio: 'Social work and psychology double major. Runs a peer support program on campus.' },
-  { username: 'timothyjackson', firstName: 'Timothy', lastName: 'Jackson', bio: 'Agricultural economics junior. Research on food deserts and market access.' },
-  { username: 'traceyholmes', firstName: 'Tracey', lastName: 'Holmes', bio: 'Statistics junior applying ML methods to healthcare outcomes research.' },
-  { username: 'trevornash', firstName: 'Trevor', lastName: 'Nash', bio: 'CS sophomore. Full-stack side projects and open source contributor.' },
-  { username: 'tylercole', firstName: 'Tyler', lastName: 'Cole', bio: 'Sports analytics junior. Python and R for basketball performance modeling.' },
-  { username: 'vanessaramirez', firstName: 'Vanessa', lastName: 'Ramirez', bio: 'International business and Spanish double major. Study abroad coordinator.' },
-  { username: 'victorchukwu', firstName: 'Victor', lastName: 'Chukwu', bio: 'Finance and economics junior. Interested in venture capital and startup ecosystems.' },
-  { username: 'victoriastone', firstName: 'Victoria', lastName: 'Stone', bio: 'Marketing and communications senior. Digital advertising campaign manager.' },
-  { username: 'wendyhamilton', firstName: 'Wendy', lastName: 'Hamilton', bio: 'Biomedical engineering senior. Capstone: wearable sensor for cardiac monitoring.' },
-  { username: 'williamford', firstName: 'William', lastName: 'Ford', bio: 'CS senior focused on distributed systems. Docker, Kubernetes, and cloud-native dev.' },
-  { username: 'xaviermeyer', firstName: 'Xavier', lastName: 'Meyer', bio: 'Data science and economics double major. Building predictive models for real estate.' },
-  { username: 'yasminenakamura', firstName: 'Yasmine', lastName: 'Nakamura', bio: 'Japanese and linguistics double major. Computational linguistics research assistant.' },
-  { username: 'zacharyevansholt', firstName: 'Zachary', lastName: 'Evans', bio: 'CS junior. Backend systems, Go, and distributed databases.' },
-  { username: 'zaraali', firstName: 'Zara', lastName: 'Ali', bio: 'Public health senior. Thesis on maternal mortality disparities in urban hospitals.' },
-  { username: 'zoeanderson', firstName: 'Zoe', lastName: 'Anderson', bio: 'Computer science junior. AI safety reading group organizer. ML + alignment research.' },
+  { username: 'aaronmitchell_demo', firstName: 'Aaron', lastName: 'Mitchell', bio: 'CS junior into cybersecurity and CTF competitions. Trying to break into bug bounty.' },
+  { username: 'abbygrant_demo', firstName: 'Abby', lastName: 'Grant', bio: 'English lit senior writing her thesis on postcolonial fiction. Coffee shop regular.' },
+  { username: 'adrianreyes_demo', firstName: 'Adrian', lastName: 'Reyes', bio: 'Mechanical engineering junior. Formula SAE team lead. Loves CAD and motorsport.' },
+  { username: 'alanawhite_demo', firstName: 'Alana', lastName: 'White', bio: 'Public health sophomore. Interested in global health policy and epidemiology.' },
+  { username: 'alexisford_demo', firstName: 'Alexis', lastName: 'Ford', bio: 'Accounting junior with a minor in data analytics. CPA prep starts next year.' },
+  { username: 'aliciamoreno_demo', firstName: 'Alicia', lastName: 'Moreno', bio: 'Architecture student designing sustainable housing. Studio life is real.' },
+  { username: 'allisonbell_demo', firstName: 'Allison', lastName: 'Bell', bio: 'Music performance major and part-time piano teacher. Classical meets jazz.' },
+  { username: 'amandalee_demo', firstName: 'Amanda', lastName: 'Lee', bio: 'Pre-law junior. Mock trial president. Interested in intellectual property law.' },
+  { username: 'amirahassan_demo', firstName: 'Amira', lastName: 'Hassan', bio: 'Neuroscience sophomore. Lab assistant studying memory consolidation.' },
+  { username: 'andrewkim_demo', firstName: 'Andrew', lastName: 'Kim', bio: 'Software engineering senior with a backend focus. Interning at a startup this summer.' },
+  { username: 'angelapark_demo', firstName: 'Angela', lastName: 'Park', bio: 'Marketing major obsessed with brand strategy and social media analytics.' },
+  { username: 'anthonygreen_demo', firstName: 'Anthony', lastName: 'Green', bio: 'Econ major with a quant focus. Interested in hedge funds and algorithmic trading.' },
+  { username: 'aryankapoor_demo', firstName: 'Aryan', lastName: 'Kapoor', bio: 'Data engineering junior. Loves Spark, Kafka, and building data pipelines at scale.' },
+  { username: 'ashleythomas_demo', firstName: 'Ashley', lastName: 'Thomas', bio: 'Kinesiology senior studying sports performance. Training for her first triathlon.' },
+  { username: 'austinwalker_demo', firstName: 'Austin', lastName: 'Walker', bio: 'Game dev enthusiast. Unity and Unreal projects in progress. Indie dev dreams.' },
+  { username: 'averyharris_demo', firstName: 'Avery', lastName: 'Harris', bio: 'Biology sophomore on the pre-vet track. Currently studying for the GRE.' },
+  { username: 'ayeshazahid_demo', firstName: 'Ayesha', lastName: 'Zahid', bio: 'Chemical engineering junior. Research in polymer synthesis and sustainable materials.' },
+  { username: 'baileyrogers_demo', firstName: 'Bailey', lastName: 'Rogers', bio: 'Political science senior interning on a state senator campaign.' },
+  { username: 'benswanson_demo', firstName: 'Ben', lastName: 'Swanson', bio: 'Stats and CS double major. Applying for quant research roles. Kaggle competitor.' },
+  { username: 'brettjohnson_demo', firstName: 'Brett', lastName: 'Johnson', bio: 'Finance junior on the investment club board. DCF and comps all day.' },
+  { username: 'brittanycox_demo', firstName: 'Brittany', lastName: 'Cox', bio: 'Communications major and campus newspaper editor. Aspiring journalist.' },
+  { username: 'camelolivier_demo', firstName: 'Camel', lastName: 'Olivier', bio: 'International relations junior. Studied abroad in Paris last semester. Fluent in French.' },
+  { username: 'carlosfernandez_demo', firstName: 'Carlos', lastName: 'Fernandez', bio: 'Electrical engineering senior specializing in signal processing and embedded systems.' },
+  { username: 'carolinehall_demo', firstName: 'Caroline', lastName: 'Hall', bio: 'Graphic design junior building her portfolio. UI/UX freelance work on the side.' },
+  { username: 'cassandralewis_demo', firstName: 'Cassandra', lastName: 'Lewis', bio: 'Sociology senior studying urban inequality and housing policy.' },
+  { username: 'chandlerdavis_demo', firstName: 'Chandler', lastName: 'Davis', bio: 'Supply chain management junior with internship at a logistics company.' },
+  { username: 'charlottehill_demo', firstName: 'Charlotte', lastName: 'Hill', bio: 'Environmental science sophomore. Research on microplastics in freshwater systems.' },
+  { username: 'chrisnguyen_demo', firstName: 'Chris', lastName: 'Nguyen', bio: 'CS and math double major. Exploring formal verification and type theory.' },
+  { username: 'christinabaker_demo', firstName: 'Christina', lastName: 'Baker', bio: 'Nursing junior. Clinical rotations start in the fall. Future ICU nurse.' },
+  { username: 'claudiavega_demo', firstName: 'Claudia', lastName: 'Vega', bio: 'Psychology senior running a study on social media and anxiety in college students.' },
+  { username: 'connorflynn_demo', firstName: 'Connor', lastName: 'Flynn', bio: 'Philosophy and CS double major. Interested in AI ethics and philosophy of mind.' },
+  { username: 'coopermartin_demo', firstName: 'Cooper', lastName: 'Martin', bio: 'Aerospace engineering junior. Rocketry club president. SpaceX internship goal.' },
+  { username: 'coreystone_demo', firstName: 'Corey', lastName: 'Stone', bio: 'Business analytics junior. Python for finance, Tableau dashboards, Excel power user.' },
+  { username: 'daniellebrown_demo', firstName: 'Danielle', lastName: 'Brown', bio: 'Creative writing MFA. Short stories published in two literary journals this year.' },
+  { username: 'davidwilson_demo', firstName: 'David', lastName: 'Wilson', bio: 'Mechanical engineering senior with a robotics specialization. ROS and SLAM all day.' },
+  { username: 'demi_okonkwo_demo', firstName: 'Demi', lastName: 'Okonkwo', bio: 'Pre-med senior. MCAT score: 518. Applying to MD/PhD programs this cycle.' },
+  { username: 'derek_santos_demo', firstName: 'Derek', lastName: 'Santos', bio: 'Sports management junior. Working on a thesis about NIL deals in college athletics.' },
+  { username: 'dianachen_demo', firstName: 'Diana', lastName: 'Chen', bio: 'Biochem and CS double major. Computational drug discovery research assistant.' },
+  { username: 'dominicross_demo', firstName: 'Dominic', lastName: 'Ross', bio: 'Economics senior writing on cryptocurrency adoption in emerging markets.' },
+  { username: 'dylanmurphy_demo', firstName: 'Dylan', lastName: 'Murphy', bio: 'Computer science sophomore. Just finished my first internship at a SaaS company.' },
+  { username: 'emilyharrison_demo', firstName: 'Emily', lastName: 'Harrison', bio: 'Art history junior with a minor in museum studies. Interning at a local gallery.' },
+  { username: 'ericrogers_demo', firstName: 'Eric', lastName: 'Rogers', bio: 'Physics senior doing undergraduate research in quantum optics lab.' },
+  { username: 'erikamorales_demo', firstName: 'Erika', lastName: 'Morales', bio: 'Industrial engineering junior. Passionate about lean manufacturing and operations research.' },
+  { username: 'ethancooper_demo', firstName: 'Ethan', lastName: 'Cooper', bio: 'CS junior specializing in NLP. Built a sentiment analysis tool for course reviews.' },
+  { username: 'evawong_demo', firstName: 'Eva', lastName: 'Wong', bio: 'Health informatics senior. Bridging EHR data and ML for clinical decision support.' },
+  { username: 'faithturner_demo', firstName: 'Faith', lastName: 'Turner', bio: 'Education major. Student teaching this semester. Passionate about math pedagogy.' },
+  { username: 'fionasmith_demo', firstName: 'Fiona', lastName: 'Smith', bio: 'Environmental studies junior. Campus sustainability committee co-chair.' },
+  { username: 'gabriellalopez_demo', firstName: 'Gabriella', lastName: 'Lopez', bio: 'Theater performance major and improv team captain. Also fluent in Spanish.' },
+  { username: 'garretthughes_demo', firstName: 'Garrett', lastName: 'Hughes', bio: 'Finance and accounting double major. Passed CFA Level I last December.' },
+  { username: 'gemmaoverton_demo', firstName: 'Gemma', lastName: 'Overton', bio: 'Biology junior with a focus on genetics. CRISPR research assistant.' },
+  { username: 'grantpayne_demo', firstName: 'Grant', lastName: 'Payne', bio: 'Management information systems senior. SAP certification in progress.' },
+  { username: 'graciecallahan_demo', firstName: 'Gracie', lastName: 'Callahan', bio: 'Social work junior. Volunteer crisis counselor. Mental health advocacy on campus.' },
+  { username: 'hannahwebb_demo', firstName: 'Hannah', lastName: 'Webb', bio: 'Journalism and political science double major. Campus radio host.' },
+  { username: 'harperscott_demo', firstName: 'Harper', lastName: 'Scott', bio: 'Marketing junior focusing on brand strategy. Founder of a small Etsy shop.' },
+  { username: 'henryfields_demo', firstName: 'Henry', lastName: 'Fields', bio: 'History and economics double major. Writing a thesis on the 2008 financial crisis.' },
+  { username: 'isabellachang_demo', firstName: 'Isabella', lastName: 'Chang', bio: 'CS sophomore interested in full-stack development. Built 3 projects this semester.' },
+  { username: 'ivannazaro_demo', firstName: 'Ivan', lastName: 'Nazaro', bio: 'Materials science and engineering senior. Research in solid-state batteries.' },
+  { username: 'jadewashington_demo', firstName: 'Jade', lastName: 'Washington', bio: "Criminal justice junior. Internship with a public defender's office this summer." },
+  { username: 'jakeoliver_demo', firstName: 'Jake', lastName: 'Oliver', bio: 'Accounting senior. Big Four internship lined up. Loves golf and tax law trivia.' },
+  { username: 'jasmineyoung_demo', firstName: 'Jasmine', lastName: 'Young', bio: 'Pre-pharmacy junior. Completing 300 hours of pharmacy observation this year.' },
+  { username: 'jasonmendez_demo', firstName: 'Jason', lastName: 'Mendez', bio: 'Civil engineering senior. Structural analysis and bridge design competition winner.' },
+  { username: 'jaydennelson_demo', firstName: 'Jayden', lastName: 'Nelson', bio: 'Sports science and exercise physiology major. Strength and conditioning coach.' },
+  { username: 'jessicaadams_demo', firstName: 'Jessica', lastName: 'Adams', bio: 'Psychology and statistics double major. Running logistic regression on clinical data.' },
+  { username: 'jonathanreeves_demo', firstName: 'Jonathan', lastName: 'Reeves', bio: 'Computer engineering junior. FPGA design and embedded Linux enthusiast.' },
+  { username: 'juliacosta_demo', firstName: 'Julia', lastName: 'Costa', bio: 'International business junior with a semester abroad in São Paulo.' },
+  { username: 'justinstewart_demo', firstName: 'Justin', lastName: 'Stewart', bio: 'CS sophomore. Currently grinding LeetCode and looking for internships.' },
+  { username: 'kaileyjones_demo', firstName: 'Kailey', lastName: 'Jones', bio: 'Elementary education major. Student teaching at Lincoln Elementary this fall.' },
+  { username: 'karenshaw_demo', firstName: 'Karen', lastName: 'Shaw', bio: 'Food science and nutrition junior. Research on gut microbiome and cognitive health.' },
+  { username: 'karlmorrison_demo', firstName: 'Karl', lastName: 'Morrison', bio: 'Philosophy junior wrestling with ethics of autonomous systems and AI.' },
+  { username: 'katelyn_price_demo', firstName: 'Katelyn', lastName: 'Price', bio: 'Marketing and design double major. Brand consulting side hustle.' },
+  { username: 'keirajohnston_demo', firstName: 'Keira', lastName: 'Johnston', bio: 'Biology senior heading to medical school in the fall. Pediatrics interest.' },
+  { username: 'kevinzhang_demo', firstName: 'Kevin', lastName: 'Zhang', bio: 'ML engineer track. PyTorch, transformers, and fine-tuning LLMs for fun.' },
+  { username: 'kiananderson_demo', firstName: 'Kian', lastName: 'Anderson', bio: 'Human-computer interaction junior. Obsessed with accessibility and inclusive design.' },
+  { username: 'kristinawills_demo', firstName: 'Kristina', lastName: 'Wills', bio: 'Communications and PR major. Runs the campus events Instagram page.' },
+  { username: 'kylewatson_demo', firstName: 'Kyle', lastName: 'Watson', bio: 'Civil and environmental engineering senior. Capstone: stormwater management system.' },
+  { username: 'laurencollins_demo', firstName: 'Lauren', lastName: 'Collins', bio: 'Human resources management junior. SHRM certification prep in progress.' },
+  { username: 'leahowens_demo', firstName: 'Leah', lastName: 'Owens', bio: 'Chemistry sophomore doing undergraduate research in organometallics.' },
+  { username: 'lewisbishop_demo', firstName: 'Lewis', lastName: 'Bishop', bio: 'Economics and philosophy double major. Writing about behavioral nudges in policy.' },
+  { username: 'lilymcgee_demo', firstName: 'Lily', lastName: 'McGee', bio: 'Graphic design senior with a portfolio in editorial illustration and branding.' },
+  { username: 'linaberger_demo', firstName: 'Lina', lastName: 'Berger', bio: 'German and international relations double major. Exchange student program coordinator.' },
+  { username: 'logancarter_demo', firstName: 'Logan', lastName: 'Carter', bio: 'CS junior doing research on distributed systems and consensus algorithms.' },
+  { username: 'luisaguerra_demo', firstName: 'Luisa', lastName: 'Guerra', bio: 'Public relations junior. Campus newspaper features editor. Aspiring media strategist.' },
+  { username: 'lukethompson_demo', firstName: 'Luke', lastName: 'Thompson', bio: 'Athletic training junior. Working with the football team as a student trainer.' },
+  { username: 'madisonperkins_demo', firstName: 'Madison', lastName: 'Perkins', bio: 'Sociology and criminology double major. Research on recidivism and prison reform.' },
+  { username: 'marcohernandez_demo', firstName: 'Marco', lastName: 'Hernandez', bio: 'Information systems senior. Specializing in ERP implementation and IT consulting.' },
+  { username: 'marissaward_demo', firstName: 'Marissa', lastName: 'Ward', bio: 'Nursing junior completing clinical hours at the county hospital. ICU focus.' },
+  { username: 'matthewevans_demo', firstName: 'Matthew', lastName: 'Evans', bio: 'CS and linguistics double major. NLP research on code-switching in bilingual texts.' },
+  { username: 'meganlewis_demo', firstName: 'Megan', lastName: 'Lewis', bio: 'Finance junior with an internship at a regional bank. CFA prep in progress.' },
+  { username: 'melissacruz_demo', firstName: 'Melissa', lastName: 'Cruz', bio: 'Healthcare management junior. Interning at a hospital administration office.' },
+  { username: 'michaelrobbins_demo', firstName: 'Michael', lastName: 'Robbins', bio: 'Physics and CS double major. Applying for PhD programs in quantum computing.' },
+  { username: 'migueltorres_demo', firstName: 'Miguel', lastName: 'Torres', bio: 'Mechanical engineering junior. Renewable energy focus. Solar car team captain.' },
+  { username: 'morgandixon_demo', firstName: 'Morgan', lastName: 'Dixon', bio: 'Psychology and data science double major. Running sentiment analysis on therapy transcripts.' },
+  { username: 'naomirichards_demo', firstName: 'Naomi', lastName: 'Richards', bio: 'Pre-med senior with a research background in infectious disease and immunology.' },
+  { username: 'nathanielbrown_demo', firstName: 'Nathaniel', lastName: 'Brown', bio: 'CS sophomore learning systems programming in Rust. OS project in progress.' },
+  { username: 'nicolassimon_demo', firstName: 'Nicolas', lastName: 'Simon', bio: 'International economics junior. Thesis on trade policy post-COVID.' },
+  { username: 'nicolewagner_demo', firstName: 'Nicole', lastName: 'Wagner', bio: 'Biology and chemistry double major on the pre-pharmacy track.' },
+  { username: 'noahcoleman_demo', firstName: 'Noah', lastName: 'Coleman', bio: 'CS junior focused on computer vision. Working on a real-time pose estimation project.' },
+  { username: 'oliviachang_demo', firstName: 'Olivia', lastName: 'Chang', bio: 'Biomedical engineering sophomore. Research in drug delivery systems.' },
+  { username: 'owenparker_demo', firstName: 'Owen', lastName: 'Parker', bio: 'Political science and communications double major. Student government vice president.' },
+  { username: 'paigethornton_demo', firstName: 'Paige', lastName: 'Thornton', bio: 'Fashion merchandising junior. Runs a sustainable fashion blog with 5k followers.' },
+  { username: 'patrickhughes_demo', firstName: 'Patrick', lastName: 'Hughes', bio: 'Finance senior with a CFA Level I. Aiming for equity research at a bulge bracket.' },
+  { username: 'paulavargas_demo', firstName: 'Paula', lastName: 'Vargas', bio: 'Biochemistry senior heading to a PhD in pharmacology. Enzyme kinetics researcher.' },
+  { username: 'philippedumont_demo', firstName: 'Philippe', lastName: 'Dumont', bio: 'French and economics double major. Exchange student from Lyon on a one-year program.' },
+  { username: 'rachelmontgomery_demo', firstName: 'Rachel', lastName: 'Montgomery', bio: 'Psychology junior doing research on trauma and cognitive behavioral therapy.' },
+  { username: 'ryanfoster_demo', firstName: 'Ryan', lastName: 'Foster', bio: 'Computer science junior. Competitive programmer, top 5% on Codeforces.' },
+  { username: 'samaraellis_demo', firstName: 'Samara', lastName: 'Ellis', bio: 'Digital marketing and analytics senior. Google Analytics certified.' },
+  { username: 'samuelwhite_demo', firstName: 'Samuel', lastName: 'White', bio: 'Operations research junior using optimization models for supply chain problems.' },
+  { username: 'sarahcampbell_demo', firstName: 'Sarah', lastName: 'Campbell', bio: 'Biostatistics senior applying for epidemiology PhD programs. R and Stata daily.' },
+  { username: 'scottmanning_demo', firstName: 'Scott', lastName: 'Manning', bio: 'History junior specializing in Cold War and US foreign policy.' },
+  { username: 'sierrarobinson_demo', firstName: 'Sierra', lastName: 'Robinson', bio: 'Environmental engineering junior. Capstone: air quality modeling for urban areas.' },
+  { username: 'stephaniegrant_demo', firstName: 'Stephanie', lastName: 'Grant', bio: 'Accounting and information systems double major. ERP systems internship this summer.' },
+  { username: 'tannerwood_demo', firstName: 'Tanner', lastName: 'Wood', bio: 'Finance junior. Investment club treasurer. Day trading on the side.' },
+  { username: 'taylormorgan_demo', firstName: 'Taylor', lastName: 'Morgan', bio: 'CS and graphic design double major. Building a design system for a startup.' },
+  { username: 'tianarobinson_demo', firstName: 'Tiana', lastName: 'Robinson', bio: 'Social work and psychology double major. Runs a peer support program on campus.' },
+  { username: 'timothyjackson_demo', firstName: 'Timothy', lastName: 'Jackson', bio: 'Agricultural economics junior. Research on food deserts and market access.' },
+  { username: 'traceyholmes_demo', firstName: 'Tracey', lastName: 'Holmes', bio: 'Statistics junior applying ML methods to healthcare outcomes research.' },
+  { username: 'trevornash_demo', firstName: 'Trevor', lastName: 'Nash', bio: 'CS sophomore. Full-stack side projects and open source contributor.' },
+  { username: 'tylercole_demo', firstName: 'Tyler', lastName: 'Cole', bio: 'Sports analytics junior. Python and R for basketball performance modeling.' },
+  { username: 'vanessaramirez_demo', firstName: 'Vanessa', lastName: 'Ramirez', bio: 'International business and Spanish double major. Study abroad coordinator.' },
+  { username: 'victorchukwu_demo', firstName: 'Victor', lastName: 'Chukwu', bio: 'Finance and economics junior. Interested in venture capital and startup ecosystems.' },
+  { username: 'victoriastone_demo', firstName: 'Victoria', lastName: 'Stone', bio: 'Marketing and communications senior. Digital advertising campaign manager.' },
+  { username: 'wendyhamilton_demo', firstName: 'Wendy', lastName: 'Hamilton', bio: 'Biomedical engineering senior. Capstone: wearable sensor for cardiac monitoring.' },
+  { username: 'williamford_demo', firstName: 'William', lastName: 'Ford', bio: 'CS senior focused on distributed systems. Docker, Kubernetes, and cloud-native dev.' },
+  { username: 'xaviermeyer_demo', firstName: 'Xavier', lastName: 'Meyer', bio: 'Data science and economics double major. Building predictive models for real estate.' },
+  { username: 'yasminenakamura_demo', firstName: 'Yasmine', lastName: 'Nakamura', bio: 'Japanese and linguistics double major. Computational linguistics research assistant.' },
+  { username: 'zacharyevansholt_demo', firstName: 'Zachary', lastName: 'Evans', bio: 'CS junior. Backend systems, Go, and distributed databases.' },
+  { username: 'zaraali_demo', firstName: 'Zara', lastName: 'Ali', bio: 'Public health senior. Thesis on maternal mortality disparities in urban hospitals.' },
+  { username: 'zoeanderson_demo', firstName: 'Zoe', lastName: 'Anderson', bio: 'Computer science junior. AI safety reading group organizer. ML + alignment research.' },
 ].map(s => ({
   ...s,
-  email: `${s.username}_demo@example.com`,
+  email: `${s.username}@example.com`,
   password: 'Demo@1234',
   settings: { activityVisibility: 'public' },
 }));
@@ -225,10 +225,10 @@ const SEED_STRANGER_USERNAMES = SEED_STRANGERS.map(s => s.username);
 // Jane's seed friends share usernames with Justin's strangers list.
 // Exclude them from deletion so seed-jane data stays intact when seed-justin --clean runs.
 const JANE_FRIEND_USERNAMES = [
-  'carolinehall', 'chrisnguyen', 'connorflynn', 'dianachen', 'ethancooper',
-  'evawong', 'graciecallahan', 'isabellachang', 'jadewashington', 'jasonmendez',
-  'kevinzhang', 'kiananderson', 'logancarter', 'michaelrobbins', 'noahcoleman',
-  'rachelmontgomery', 'ryanfoster', 'taylormorgan', 'trevornash', 'zoeanderson',
+  'carolinehall_demo', 'chrisnguyen_demo', 'connorflynn_demo', 'dianachen_demo', 'ethancooper_demo',
+  'evawong_demo', 'graciecallahan_demo', 'isabellachang_demo', 'jadewashington_demo', 'jasonmendez_demo',
+  'kevinzhang_demo', 'kiananderson_demo', 'logancarter_demo', 'michaelrobbins_demo', 'noahcoleman_demo',
+  'rachelmontgomery_demo', 'ryanfoster_demo', 'taylormorgan_demo', 'trevornash_demo', 'zoeanderson_demo',
 ];
 
 // ─── Clean Function ─────────────────────────────────────────────────────────
@@ -281,12 +281,16 @@ async function seedFriends() {
   const friends = [];
 
   for (const data of SEED_FRIENDS) {
-    let user = await User.findOne({ username: data.username });
+    let user = await User.findOne({ $or: [{ username: data.username }, { email: data.email }] });
     if (!user) {
       user = new User({ ...data, isSeedUser: true });
       await user.save();
       console.log(`  Created user: ${data.username}`);
     } else {
+      if (user.username !== data.username) {
+        user.username = data.username;
+        await user.save();
+      }
       console.log(`  User exists: ${data.username}`);
     }
     friends.push(user);
@@ -302,10 +306,13 @@ async function seedStrangers() {
   let created = 0;
 
   for (const data of SEED_STRANGERS) {
-    const existing = await User.findOne({ username: data.username });
+    const existing = await User.findOne({ $or: [{ username: data.username }, { email: data.email }] });
     if (!existing) {
       await new User({ ...data, isSeedUser: true }).save();
       created++;
+    } else if (existing.username !== data.username) {
+      existing.username = data.username;
+      await existing.save();
     }
   }
 
@@ -346,10 +353,10 @@ async function seedFriendships(justin, friends) {
 
   const interFriendPairs = [
     ['alexchen_cs', 'mayapatel_ds'],
-    ['alexchen_cs', 'jordanwilliams'],
-    ['mayapatel_ds', 'priyasharma'],
-    ['marcusjohnson', 'sofiarod'],
-    ['jordanwilliams', 'marcusjohnson'],
+    ['alexchen_cs', 'jordanwilliams_demo'],
+    ['mayapatel_ds', 'priyasharma_demo'],
+    ['marcusjohnson_demo', 'sofiarod_demo'],
+    ['jordanwilliams_demo', 'marcusjohnson_demo'],
   ];
 
   for (const [u1, u2] of interFriendPairs) {
@@ -734,10 +741,10 @@ async function seedTasks(justin, friends) {
   // ── Shared tasks: Justin → friends ────────────────────────────────────────
   const alexId    = friendMap.alexchen_cs._id;
   const mayaId    = friendMap.mayapatel_ds._id;
-  const jordanId  = friendMap.jordanwilliams._id;
-  const priyaId   = friendMap.priyasharma._id;
-  const marcusId  = friendMap.marcusjohnson._id;
-  const sofiaId   = friendMap.sofiarod._id;
+  const jordanId  = friendMap.jordanwilliams_demo._id;
+  const priyaId   = friendMap.priyasharma_demo._id;
+  const marcusId  = friendMap.marcusjohnson_demo._id;
+  const sofiaId   = friendMap.sofiarod_demo._id;
 
   const sharedTaskDefs = [
     {
@@ -948,10 +955,10 @@ async function seedConversations(justin, friends) {
   const convKeys = [
     { key: 'alex', username: 'alexchen_cs' },
     { key: 'maya', username: 'mayapatel_ds' },
-    { key: 'jordan', username: 'jordanwilliams' },
-    { key: 'priya', username: 'priyasharma' },
-    { key: 'marcus', username: 'marcusjohnson' },
-    { key: 'sofia', username: 'sofiarod' },
+    { key: 'jordan', username: 'jordanwilliams_demo' },
+    { key: 'priya', username: 'priyasharma_demo' },
+    { key: 'marcus', username: 'marcusjohnson_demo' },
+    { key: 'sofia', username: 'sofiarod_demo' },
   ];
 
   for (const { key, username } of convKeys) {
@@ -1803,6 +1810,7 @@ async function main() {
     process.exit(1);
   } finally {
     await mongoose.disconnect();
+    process.exit(0);
   }
 }
 

--- a/backend/scripts/seed-justin.js
+++ b/backend/scripts/seed-justin.js
@@ -236,8 +236,15 @@ const JANE_FRIEND_USERNAMES = [
 async function cleanSeedData(justinId) {
   console.log('Cleaning seed data...');
 
-  // Look up seed friend IDs
-  const seedUsers = await User.find({ username: { $in: SEED_USERNAMES } });
+  // Find ALL seed users by flag — works regardless of current username, handling
+  // migration from old usernames (e.g. 'sofiarod' → 'sofiarod_demo').
+  // Exclude Justin and Jane's friends (identified by their stable emails).
+  const janeFriendEmails = JANE_FRIEND_USERNAMES.map(u => `${u}@example.com`);
+  const seedUsers = await User.find({
+    isSeedUser: true,
+    _id: { $ne: justinId },
+    email: { $nin: janeFriendEmails },
+  });
   const seedIds = seedUsers.map(u => u._id);
   const allIds = [justinId, ...seedIds];
 
@@ -266,10 +273,8 @@ async function cleanSeedData(justinId) {
     ],
   });
 
-  // Delete the seed friend users and stranger users (NOT Justin, NOT Jane's friends)
-  await User.deleteMany({
-    username: { $in: [...SEED_USERNAMES, ...SEED_STRANGER_USERNAMES], $nin: JANE_FRIEND_USERNAMES },
-  });
+  // Delete the seed friend and stranger users (not Justin, not Jane's friends)
+  await User.deleteMany({ _id: { $in: seedIds } });
 
   console.log('Clean complete.');
 }

--- a/docs/continuum-interview-brief.md
+++ b/docs/continuum-interview-brief.md
@@ -48,7 +48,7 @@ Built over 8 weeks for the 2026 All Star Code Technical Entrepreneurship Incubat
 | Storage | Cloudinary (images, PDFs) |
 | Email | Resend — transactional from `noreply@usecontinuum.dev` (custom domain) |
 | Auth | JWT access tokens, httpOnly refresh cookies, Google OAuth 2.0 |
-| Monitoring | Sentry (backend `@sentry/node` + frontend `@sentry/react`) |
+| Monitoring | Sentry (backend `@sentry/node` + frontend `@sentry/react`), PostHog (product analytics + session replay) |
 | Deployment | Vercel (frontend) + Render Starter (backend) + Upstash Redis |
 | CI | GitHub Actions — Jest, Playwright E2E, and Android unit tests run in parallel on every PR |
 
@@ -1029,6 +1029,84 @@ The resume prompt is the most complex. Key techniques used:
 | `generateSummary` | 25/user/day | Core feature, high frequency |
 | `generateFlashcards` | 25/user/day | Core feature, high frequency |
 | `generateResumeFeedback` | 5/user/day | Expensive output, lower frequency |
+
+---
+
+## Observability & Analytics — Deep Dive
+
+### Architecture
+
+Two-layer observability stack:
+- **Sentry** — error monitoring and crash reporting. Backend initialized via `instrument.js` before Express loads; frontend initialized in `main.jsx` before React renders. Sentry errors are tagged with `posthog_session_replay_url` so you can click directly from an error to the session replay that triggered it.
+- **PostHog** — product analytics, session replay, and activation funnel tracking.
+
+### Ad Blocker Bypass via Vercel Proxy
+
+The PostHog SDK is configured with `api_host: '/ph'` (relative path) instead of `https://us.i.posthog.com`. Vercel rewrites in `vercel.json` forward `/ph/*` to PostHog's ingestion endpoint:
+
+```json
+{ "source": "/ph/:path*", "destination": "https://us.i.posthog.com/:path*" }
+```
+
+Ad blockers block `us.i.posthog.com` by hostname. They see `usecontinuum.dev/ph` — your domain — and let it through. This is a standard production pattern; PostHog documents it as the recommended deployment for apps where ad blocker interference matters.
+
+### Identity Model
+
+Both frontend and backend use MongoDB `_id` as the PostHog `distinctId`. On login or register, the frontend calls:
+```js
+posthog.identify(user._id, { email, username, name, created_at })
+```
+The backend sends server-side events via a central `capture(user, event, props)` wrapper in `backend/lib/posthog.js`. Because both sides use the same ID, all events — frontend page views, backend write events — merge into a single user profile in PostHog automatically.
+
+### Person Profiles: `identified_only`
+
+PostHog's person profile mode is set to `identified_only`, meaning anonymous pre-login sessions are not stored as person records — only users who register and are identified generate person profiles. However, anonymous `$pageview` events on the marketing and login pages are still captured intentionally.
+
+When an anonymous visitor registers and `posthog.identify()` fires, PostHog retroactively merges their anonymous session into the new person profile. This preserves the full pre-signup journey — the only way to measure landing page → registration conversion rate. All non-auth pages in the app are marketing or login pages, so there is no risk of capturing anonymous events on authenticated views.
+
+### Demo & Seed Account Exclusion
+
+The demo account (`isDemo: true`) and all seed bot accounts (`isSeedUser: true`) are completely excluded from PostHog:
+
+**Frontend:** On login or hydration, if `user.isDemo || user.isSeedUser`, `posthog.opt_out_capturing()` is called. This disables ALL tracking for that session — including autocapture and automatic `$pageview` events, which cannot be blocked with a simple `if` guard. On logout, `posthog.opt_in_capturing()` restores the default state for the next real user.
+
+**Backend:** `backend/lib/posthog.js` exports a `capture(user, event, props)` wrapper that checks `user.isDemo || user.isSeedUser` before forwarding to the PostHog client. All controllers call this wrapper, so the guard is in one place — no per-controller checks.
+
+### Session Replay with PII Masking
+
+Session recording is enabled with explicit masks on `[type=password]` and `[type=email]`. This captures full interaction recordings while automatically redacting credentials. You can replay exactly what a user did leading up to a bug or drop-off point.
+
+### Backend Batching & Graceful Shutdown
+
+The backend PostHog client flushes in batches (`flushAt: 20` events or every 10 seconds) rather than per-event HTTP calls. On process shutdown, `posthog.shutdown()` is called explicitly to flush any queued events before the Node.js process exits — ensuring no events are lost on Render deploys.
+
+### Event Catalog (35 custom events)
+
+Events are split between frontend (UI interactions) and backend (data mutations):
+
+**Auth:** `user_registered`, `user_logged_in` (method: email|google), `user_logged_out`, `email_verified`, `google_auth_linked`, `account_deletion_requested`, `account_restored`
+
+**Notes:** `note_created` (source: manual|pdf_upload|google_doc), `note_viewed`, `note_shared` (audience, recipientCount), `note_unshared`, `note_deleted`, `note_summary_generated`, `google_doc_imported`
+
+**Flashcards:** `flashcard_set_generated` (source, card_count, generation_path), `flashcard_set_viewed`, `flashcard_set_shared`, `flashcard_set_unshared`, `flashcard_set_deleted`
+
+**Study:** `study_session_started`, `study_session_completed`, `study_session_abandoned` (cards_seen)
+
+**Career:** `resume_uploaded`, `resume_feedback_generated`, `resume_score_viewed`, `job_application_created`
+
+**Social:** `friend_request_sent`, `friend_request_accepted`, `friend_removed`, `message_sent`, `task_shared`, `task_created`, `comment_added`, `comment_reply_added`
+
+### Activation Funnel
+
+The defined activation event — the "aha moment" — is:
+```
+user_registered → (flashcard_set_generated OR note_summary_generated OR resume_feedback_generated)
+```
+Conversion window: 7 days. This tracks whether new users reach the AI-powered core of the product, which is the primary retention driver.
+
+### Source Tracking
+
+Notes and flashcards capture `source` on creation (`manual`, `pdf_upload`, `google_doc`, `text_paste`). This tells you which input modes users actually use — data that directly informs where to invest in UX improvements.
 
 ---
 

--- a/docs/observability/architecture.md
+++ b/docs/observability/architecture.md
@@ -120,12 +120,39 @@ Go to **PostHog → Dashboards → Launch → Activation Funnel**. After complet
 
 ---
 
+## Demo & Seed Account Exclusion
+
+The demo account (`isDemo: true`) and all seeded bot accounts (`isSeedUser: true`) are completely silenced from PostHog at two layers:
+
+**Frontend — `posthog.opt_out_capturing()`**  
+In `web/src/context/AuthContext.jsx` and `web/src/pages/auth/AuthCallback.jsx`, after the user object is set on login/hydration, the code checks `user.isDemo || user.isSeedUser`. If true, `posthog.opt_out_capturing()` is called. This disables all PostHog tracking for that browser session — including autocapture and automatic `$pageview` events that cannot be blocked with a simple conditional.
+
+On logout, `posthog.opt_in_capturing()` is always called to restore the default state for the next user who logs in on that browser.
+
+**Backend — centralized `capture()` wrapper**  
+`backend/lib/posthog.js` exports a `capture(user, event, props)` wrapper instead of the raw PostHog client. The wrapper checks `user.isDemo || user.isSeedUser` and silently returns without forwarding the event. All controllers call `posthog.capture(req.user, ...)`, so the guard is enforced in one place.
+
+**PostHog dashboard (belt-and-suspenders)**  
+A "Real users" cohort (person property `isDemo is not true`) is applied as a filter on all dashboards and saved insights. Even if a demo event somehow slipped through the code guards, it would be excluded from all charts.
+
+---
+
+## Anonymous Tracking on Marketing Pages
+
+Anonymous `$pageview` events on the landing page and login page are intentionally retained — they are not blocked or filtered.
+
+With `person_profiles: 'identified_only'`, anonymous sessions do not create person records in PostHog. But when the visitor later registers and `posthog.identify()` fires, PostHog retroactively merges the anonymous session into the new person profile. This preserves the full pre-signup journey and enables the landing page → registration conversion funnel.
+
+All non-auth pages in the app are marketing or login pages, so there is no risk of capturing anonymous events on authenticated views.
+
+---
+
 ## Clean Slate Before Launch
 
 Before your product launch, wipe all test data:
 
-**MongoDB Atlas:**  
-Drop all collections or use the Atlas UI to delete and recreate the database. This removes all test users, notes, flashcard sets, etc.
+**MongoDB:**  
+Run `node backend/scripts/reset-prod.js` (after setting `MONGODB_URI` in `backend/.env` to your prod Atlas URI). The script prints document counts per collection and requires you to type `RESET` to confirm before dropping anything. Then re-seed: `node backend/scripts/seed-jane.js && node backend/scripts/seed-justin.js`.
 
 **PostHog:**  
 Settings → Project → Reset project data. This wipes all persons and events while preserving your project key, funnel configuration, and dashboard setup.

--- a/docs/observability/events.md
+++ b/docs/observability/events.md
@@ -2,6 +2,8 @@
 
 All custom events tracked in Continuum. Every event is either fired from the **frontend** (React web, `posthog-js`) or the **backend** (Node.js, `posthog-node`).
 
+> **Demo & seed accounts are fully opted out.** No events fire for accounts where `isDemo: true` or `isSeedUser: true`. The frontend calls `posthog.opt_out_capturing()` on login for these accounts, and the backend `capture()` wrapper silently drops all events before they reach the PostHog client.
+
 ---
 
 ## Identity

--- a/web/src/context/AuthContext.jsx
+++ b/web/src/context/AuthContext.jsx
@@ -99,12 +99,16 @@ export function AuthProvider({ children }) {
       .then((res) => {
         const u = res.data.user || res.data.data;
         setUser(u);
-        posthog.identify(u._id, {
-          email: u.email,
-          username: u.username,
-          name: `${u.firstName ?? ''} ${u.lastName ?? ''}`.trim() || u.username,
-          created_at: u.createdAt,
-        });
+        if (u.isDemo || u.isSeedUser) {
+          posthog.opt_out_capturing();
+        } else {
+          posthog.identify(u._id, {
+            email: u.email,
+            username: u.username,
+            name: `${u.firstName ?? ''} ${u.lastName ?? ''}`.trim() || u.username,
+            created_at: u.createdAt,
+          });
+        }
         // Reconnect socket on page refresh if already logged in
         const socket = connectSocket(token);
         registerSocketEvents(socket);
@@ -121,13 +125,17 @@ export function AuthProvider({ children }) {
     const { token, user: u } = res.data;
     localStorage.setItem('token', token);
     setUser(u);
-    posthog.identify(u._id, {
-      email: u.email,
-      username: u.username,
-      name: `${u.firstName ?? ''} ${u.lastName ?? ''}`.trim() || u.username,
-      created_at: u.createdAt,
-    });
-    posthog.capture('user_logged_in', { platform: 'web', method: 'email' });
+    if (u.isDemo || u.isSeedUser) {
+      posthog.opt_out_capturing();
+    } else {
+      posthog.identify(u._id, {
+        email: u.email,
+        username: u.username,
+        name: `${u.firstName ?? ''} ${u.lastName ?? ''}`.trim() || u.username,
+        created_at: u.createdAt,
+      });
+      posthog.capture('user_logged_in', { platform: 'web', method: 'email' });
+    }
     const socket = connectSocket(token);
     registerSocketEvents(socket);
     return u;
@@ -138,20 +146,27 @@ export function AuthProvider({ children }) {
     const { token, user: u } = res.data;
     localStorage.setItem('token', token);
     setUser(u);
-    posthog.identify(u._id, {
-      email: u.email,
-      username: u.username,
-      name: `${u.firstName ?? ''} ${u.lastName ?? ''}`.trim() || u.username,
-      created_at: u.createdAt,
-    });
-    posthog.capture('user_registered', { platform: 'web', method: 'email' });
+    if (u.isDemo || u.isSeedUser) {
+      posthog.opt_out_capturing();
+    } else {
+      posthog.identify(u._id, {
+        email: u.email,
+        username: u.username,
+        name: `${u.firstName ?? ''} ${u.lastName ?? ''}`.trim() || u.username,
+        created_at: u.createdAt,
+      });
+      posthog.capture('user_registered', { platform: 'web', method: 'email' });
+    }
     const socket = connectSocket(token);
     registerSocketEvents(socket);
     return u;
   }, []);
 
   const logout = useCallback(() => {
-    posthog.capture('user_logged_out', { platform: 'web' });
+    if (!posthog.has_opted_out_capturing()) {
+      posthog.capture('user_logged_out', { platform: 'web' });
+    }
+    posthog.opt_in_capturing();
     posthog.reset();
     api.post('/auth/logout').catch(() => {});
     disconnectSocket();

--- a/web/src/pages/auth/AuthCallback.jsx
+++ b/web/src/pages/auth/AuthCallback.jsx
@@ -34,13 +34,17 @@ export default function AuthCallback() {
         const user = res.data.user || res.data.data;
         queryClient.invalidateQueries({ queryKey: ['me'] });
         updateUser(user);
-        posthog.identify(user._id, {
-          email: user.email,
-          username: user.username,
-          name: `${user.firstName ?? ''} ${user.lastName ?? ''}`.trim() || user.username,
-          created_at: user.createdAt,
-        });
-        posthog.capture('user_logged_in', { platform: 'web', method: 'google' });
+        if (user.isDemo || user.isSeedUser) {
+          posthog.opt_out_capturing();
+        } else {
+          posthog.identify(user._id, {
+            email: user.email,
+            username: user.username,
+            name: `${user.firstName ?? ''} ${user.lastName ?? ''}`.trim() || user.username,
+            created_at: user.createdAt,
+          });
+          posthog.capture('user_logged_in', { platform: 'web', method: 'google' });
+        }
         navigate('/dashboard');
       })
       .catch(() => {


### PR DESCRIPTION
## Summary

- **Seed username collision fix**: All seed account usernames renamed to `*_demo` suffix (`janedoe_demo`, `carolinehall_demo`, `aaronmitchell_demo`, etc.) so real users can register any plain name. Email-based fallback lookups handle one-time migration from old usernames without duplicate key errors.
- **PostHog demo/seed silencing**: Demo (`isDemo: true`) and seed (`isSeedUser: true`) accounts now fire zero PostHog events. Frontend uses `posthog.opt_out_capturing()` to kill autocapture and pageviews; backend uses a central `capture(user, event, props)` wrapper that guards all 22 call sites in one place.
- **reset-prod.js**: New script to drop all user-generated collections before launch. Shows doc counts, requires typing `RESET` to confirm, reads `MONGODB_URI` from `backend/.env`.
- **Observability docs**: Full PostHog deep-dive added to interview brief; `architecture.md` and `events.md` updated with demo exclusion and anonymous tracking rationale.

## Test plan

- [ ] `node backend/scripts/seed-jane.js --clean` completes without errors
- [ ] `node backend/scripts/seed-justin.js --clean --no-ai` completes without errors
- [ ] Search for `janedoe` in friend search → 0 results
- [ ] Register a new account with username `janedoe` → succeeds
- [ ] Log in as demo account, check PostHog Live Events → nothing fires
- [ ] Log in as real user, check PostHog Live Events → events appear correctly
- [ ] `node backend/scripts/reset-prod.js` without typing RESET → aborts cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)