### PR TITLE
feat: instant real-time for messages, friends, and unread indicators

### DIFF
--- a/backend/controllers/conversations.controller.js
+++ b/backend/controllers/conversations.controller.js
@@ -92,7 +92,15 @@ exports.getConversations = async (req, res) => {
         .populate('participants', 'username firstName lastName avatarUrl roles')
         .sort({ 'lastMessage.sentAt': -1, createdAt: -1 });
 
-    res.status(200).json({ success: true, conversations });
+    // Pluck the current user's unread count from the array and expose as a scalar
+    const serialized = conversations.map(conv => {
+        const raw = conv.toObject();
+        const entry = raw.unreadCounts?.find(u => u.userId?.toString() === userId.toString());
+        raw.unreadCount = entry?.count ?? 0;
+        return raw;
+    });
+
+    res.status(200).json({ success: true, conversations: serialized });
 };
 
 // ----------------------------------------

--- a/web/src/components/layout/MessagesLayout.jsx
+++ b/web/src/components/layout/MessagesLayout.jsx
@@ -141,11 +141,26 @@ export default function MessagesLayout() {
               const lastMsg = conv.lastMessage;
               const isLastMine = lastMsg?.senderId === user?._id;
               const isActive = activeConversationId === conv._id;
+              const hasUnread = !isActive && (conv.unreadCount || 0) > 0;
 
               return (
                 <div
                   key={conv._id}
-                  onClick={() => setActiveConversationId(conv._id)}
+                  onClick={() => {
+                    setActiveConversationId(conv._id);
+                    // Optimistically clear unread badge on open
+                    if (hasUnread) {
+                      queryClient.setQueryData(['conversations'], old => {
+                        if (!old) return old;
+                        return {
+                          ...old,
+                          conversations: (old.conversations || []).map(c =>
+                            c._id === conv._id ? { ...c, unreadCount: 0 } : c
+                          ),
+                        };
+                      });
+                    }
+                  }}
                   style={{
                     display: 'flex',
                     alignItems: 'center',
@@ -165,20 +180,28 @@ export default function MessagesLayout() {
                   <AppAvatar name={getName(other)} src={other?.avatarUrl} size="md" />
                   <div style={{ flex: 1, minWidth: 0 }}>
                     <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 2 }}>
-                      <p style={{ fontSize: 14, fontWeight: 600, color: '#111827', margin: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                      <p style={{ fontSize: 14, fontWeight: hasUnread ? 700 : 600, color: hasUnread ? '#111827' : '#374151', margin: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
                         {getName(other)}
                       </p>
                       <div style={{ display: 'flex', alignItems: 'center', gap: 6, flexShrink: 0, marginLeft: 8 }}>
                         {lastMsg?.sentAt && (
-                          <span style={{ fontSize: 11, color: '#9CA3AF' }}>{formatRelative(lastMsg.sentAt)}</span>
+                          <span style={{ fontSize: 11, color: hasUnread ? '#6b21a8' : '#9CA3AF', fontWeight: hasUnread ? 600 : 400 }}>{formatRelative(lastMsg.sentAt)}</span>
                         )}
-                        {conv.unreadCount > 0 && (
-                          <div style={{ width: 8, height: 8, borderRadius: '50%', background: '#6b21a8', flexShrink: 0 }} />
+                        {hasUnread && (
+                          <div style={{
+                            minWidth: 18, height: 18, borderRadius: 9,
+                            background: '#6b21a8', color: '#fff',
+                            fontSize: 10, fontWeight: 700,
+                            display: 'flex', alignItems: 'center', justifyContent: 'center',
+                            padding: '0 5px', flexShrink: 0,
+                          }}>
+                            {conv.unreadCount > 99 ? '99+' : conv.unreadCount}
+                          </div>
                         )}
                       </div>
                     </div>
                     {lastMsg ? (
-                      <p style={{ fontSize: 12, color: '#9CA3AF', margin: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                      <p style={{ fontSize: 12, color: hasUnread ? '#4B5563' : '#9CA3AF', fontWeight: hasUnread ? 500 : 400, margin: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
                         {isLastMine ? 'You: ' : ''}{previewText(lastMsg.content)}
                       </p>
                     ) : (

--- a/web/src/context/AuthContext.jsx
+++ b/web/src/context/AuthContext.jsx
@@ -8,18 +8,50 @@ const AuthContext = createContext(null);
 
 // All socket events and which React Query keys they invalidate
 function registerSocketEvents(socket) {
-  // Direct messages — invalidate the conversation and inbox
-  socket.on('new_message', ({ conversationId }) => {
-    queryClient.invalidateQueries({ queryKey: ['messages', conversationId] });
-    queryClient.invalidateQueries({ queryKey: ['conversations'] });
+  // Direct messages — write directly into cache for instant display, then sync sidebar
+  socket.on('new_message', ({ conversationId, message }) => {
+    // Insert into any open message query for this conversation (skip active search results)
+    const queries = queryClient.getQueriesData({ queryKey: ['messages', conversationId] });
+    queries.forEach(([key, data]) => {
+      const searchTerm = key[2];
+      if (!searchTerm && data) {
+        queryClient.setQueryData(key, old => ({
+          ...old,
+          messages: [message, ...(old?.messages || [])],
+        }));
+      }
+    });
+    // Update conversations sidebar: bump lastMessage preview + unread count, re-sort
+    queryClient.setQueryData(['conversations'], old => {
+      if (!old) return old;
+      const updated = (old.conversations || []).map(conv =>
+        conv._id === conversationId
+          ? {
+              ...conv,
+              lastMessage: {
+                senderId: message.senderId?._id ?? message.senderId,
+                content: message.content,
+                sentAt: message.createdAt,
+              },
+              unreadCount: (conv.unreadCount || 0) + 1,
+            }
+          : conv
+      );
+      updated.sort(
+        (a, b) => new Date(b.lastMessage?.sentAt || 0) - new Date(a.lastMessage?.sentAt || 0)
+      );
+      return { ...old, conversations: updated };
+    });
   });
 
-  // Friend requests / accepted
+  // Friend requests / accepted — invalidate all three friend query keys
   socket.on('friend_request', () => {
     queryClient.invalidateQueries({ queryKey: ['friends'] });
+    queryClient.invalidateQueries({ queryKey: ['friend-requests'] });
   });
   socket.on('friend_accepted', () => {
     queryClient.invalidateQueries({ queryKey: ['friends'] });
+    queryClient.invalidateQueries({ queryKey: ['friend-requests-sent'] });
   });
 
   // Task mutations — existing and new Phase 2 events

--- a/web/src/lib/socket.js
+++ b/web/src/lib/socket.js
@@ -12,7 +12,7 @@ export function connectSocket(token) {
   socket = io(import.meta.env.VITE_API_URL || 'http://localhost:5001', {
     auth: { token },
     transports: ['websocket'],
-    reconnectionAttempts: 5,
+    reconnectionDelayMax: 5000,
   });
 
   return socket;

--- a/web/src/pages/messages/Conversation.jsx
+++ b/web/src/pages/messages/Conversation.jsx
@@ -112,16 +112,33 @@ export default function Conversation({ conversationId }) {
         if (!old) return old;
         return { ...old, messages: [...(old.messages || []), tempMsg] };
       });
+      // Instantly move this conversation to the top of the sidebar with the new preview
+      queryClient.setQueryData(['conversations'], old => {
+        if (!old) return old;
+        const updated = (old.conversations || []).map(conv =>
+          conv._id === conversationId
+            ? { ...conv, lastMessage: { senderId: user?._id, content: content.substring(0, 200), sentAt: tempMsg.createdAt } }
+            : conv
+        );
+        updated.sort((a, b) => new Date(b.lastMessage?.sentAt || 0) - new Date(a.lastMessage?.sentAt || 0));
+        return { ...old, conversations: updated };
+      });
       return { prev };
     },
     onError: (_err, _content, ctx) => {
       if (ctx?.prev) queryClient.setQueryData(msgQueryKey, ctx.prev);
     },
-    onSuccess: () => {
+    onSuccess: (res) => {
       posthog.capture('message_sent', { platform: 'web' });
       setMessage('');
-      refetch();
-      queryClient.invalidateQueries({ queryKey: ['conversations'] });
+      // Swap the temp placeholder with the real server message — no extra network request needed
+      const realMsg = res.data?.message;
+      if (realMsg) {
+        queryClient.setQueryData(msgQueryKey, old => {
+          if (!old) return old;
+          return { ...old, messages: old.messages.map(m => m._temp ? realMsg : m) };
+        });
+      }
     },
     onSettled: () => queryClient.invalidateQueries({ queryKey: msgQueryKey }),
   });
@@ -133,14 +150,20 @@ export default function Conversation({ conversationId }) {
   useEffect(() => {
     if (!user || !data) return;
     const messages = data?.messages || [];
+    let markedAny = false;
     messages.forEach(msg => {
       const senderId = msg.senderId?._id ?? msg.senderId;
       const isOwn = senderId === user._id;
       if (!isOwn && !markedReadRef.current.has(msg._id)) {
         markedReadRef.current.add(msg._id);
         api.put(`/messages/${msg._id}/read`).catch(() => {});
+        markedAny = true;
       }
     });
+    // Sync sidebar unread count after marking messages read
+    if (markedAny) {
+      queryClient.invalidateQueries({ queryKey: ['conversations'] });
+    }
   }, [data, user]);
 
   const handleSend = useCallback(() => {


### PR DESCRIPTION
## Summary

- **Socket resilience**: Removed `reconnectionAttempts: 5` cap — socket now reconnects indefinitely after backend restarts, eliminating the need to hard-reload to restore real-time
- **Instant messages (both sides)**: Recipients get new messages via direct `setQueryData` on the `new_message` socket event — no server round-trip. Senders get an instant sidebar preview update in `onMutate` and temp message is swapped with the real server response in `onSuccess` (removes redundant `refetch()` call)
- **Friend request real-time**: `friend_request` now invalidates `['friend-requests']` so the recipient's Requests tab updates live; `friend_accepted` now invalidates `['friend-requests-sent']` so the requester's Sent tab clears live
- **Unread indicator**: Fixed a serialization bug where the backend returned `unreadCounts: [{ userId, count }]` (array) but the frontend read `conv.unreadCount` (scalar — always `undefined`). `getConversations` now plucks the requesting user's count and exposes it as a scalar. UI updated to show a numeric pill badge, bold name, and purple timestamp for unread conversations. Clicking a conversation optimistically zeroes the badge immediately; `markAsRead` then invalidates `['conversations']` to sync the confirmed count

## Test plan

- [ ] Open two browser sessions as two different users who are friends
- [ ] **Instant messages**: Send a message from user A — it should appear on user B's screen within ~100ms with no reload. Sidebar preview and unread badge should update in the same tick
- [ ] **Unread badge**: While user B is away from `/messages`, have user A send a message. Navigate user B to `/messages` — conversation should show the purple count badge, bold name, and purple timestamp. Click it — badge clears immediately
- [ ] **Friend request live update**: Have user C send user D a friend request — D's Requests tab should update live without reload. D accepts — C's Sent tab should clear and Friends tab should gain D, all without reload
- [ ] **Socket resilience**: Restart the backend while a client is connected. Confirm the client reconnects automatically and messages flow again without a hard reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)