### PR TITLE
fix: remove Redis list caching and fix stale data across all mutations

### DIFF
--- a/android/app/src/main/java/com/continuum/android/feature/career/data/repository/CareerRepository.kt
+++ b/android/app/src/main/java/com/continuum/android/feature/career/data/repository/CareerRepository.kt
@@ -59,7 +59,9 @@ class CareerRepository @Inject constructor(
     )
 
     suspend fun createApplication(company: String, position: String, status: String, jobUrl: String?): Result<Application> = runCatching {
-        api.createApplication(CreateApplicationRequestDto(company, position, status, jobUrl)).application.toDomain()
+        val app = api.createApplication(CreateApplicationRequestDto(company, position, status, jobUrl)).application
+        appDao.insert(app.toDomain().toEntity())
+        app.toDomain()
     }
 
     suspend fun updateApplication(id: String, status: String?, notes: String?): Result<Application> = runCatching {

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -42,8 +42,16 @@ RESEND_API_KEY=your-resend-api-key
 # Frontend URL (for CORS)
 FRONTEND_URL=http://localhost:5173
 
-# Redis (optional — enables server-side caching and per-user AI rate limiting)
-# REDIS_URL=redis://localhost:6379
+# Redis — JWT revocation + per-user AI rate limiting
+# Not used for list/CRUD caching (MongoDB is fast enough at this scale).
+# Optional locally — without it the app runs fine, AI rate limits are just not enforced.
+#
+# Setup (Mac):
+#   brew install redis
+#   brew services start redis   # starts in background, survives restarts
+#   redis-cli ping              # should print PONG
+#
+REDIS_URL=redis://localhost:6379
 
 # Special Role Auto-Assignment (comma-separated emails)
 # Users registering with these emails are automatically assigned the corresponding role.

--- a/backend/controllers/activity.controller.js
+++ b/backend/controllers/activity.controller.js
@@ -1,5 +1,4 @@
 const Activity = require('../models/Activity');
-const { getOrSet } = require('../lib/cache');
 
 // ============================================================
 // ACTIVITY CONTROLLER
@@ -99,7 +98,7 @@ exports.getActivityFeed = async (req, res) => {
     // Cache each cursor page for 5 minutes — pages are stable (new items always land above the cursor)
     // total is always fresh (not cached) so it never goes stale after a seed re-run or new activity
     const [result, total] = await Promise.all([
-        useCache ? getOrSet(cacheKey, 300, fetchFeed) : fetchFeed(),
+        fetchFeed(),
         Activity.countDocuments(countFilter),
     ]);
 

--- a/backend/controllers/applications.controller.js
+++ b/backend/controllers/applications.controller.js
@@ -1,7 +1,7 @@
 const mongoose = require('mongoose');
 const Application = require('../models/Application');
 const posthog = require('../lib/posthog');
-const { getOrSet, invalidatePattern } = require('../lib/cache');
+const { invalidatePattern } = require('../lib/cache');
 
 // ============================================================
 // APPLICATIONS CONTROLLER
@@ -83,9 +83,7 @@ exports.getApplications = async (req, res) => {
     const cacheKey = `applications:${req.user._id.toString()}:${search || ''}:${status || ''}`;
     const fetchApps = () => Application.find(filter).sort({ createdAt: -1 });
 
-    const applications = search
-        ? await fetchApps()
-        : await getOrSet(cacheKey, 120, fetchApps);
+    const applications = await fetchApps();
 
     res.status(200).json({ success: true, applications });
 };

--- a/backend/controllers/applications.controller.js
+++ b/backend/controllers/applications.controller.js
@@ -197,6 +197,7 @@ exports.addContact = async (req, res) => {
     }
 
     const newContact = application.contacts[application.contacts.length - 1];
+    await invalidatePattern(`applications:${req.user._id.toString()}`).catch(() => {});
     res.status(201).json({ success: true, contact: newContact, application });
 };
 
@@ -227,6 +228,7 @@ exports.addReminder = async (req, res) => {
     }
 
     const newReminder = application.followUpReminders[application.followUpReminders.length - 1];
+    await invalidatePattern(`applications:${req.user._id.toString()}`).catch(() => {});
     res.status(201).json({ success: true, reminder: newReminder, application });
 };
 
@@ -253,6 +255,7 @@ exports.deleteContact = async (req, res) => {
     if (!application) {
         return res.status(404).json({ success: false, error: 'Application not found' });
     }
+    await invalidatePattern(`applications:${req.user._id.toString()}`).catch(() => {});
     res.status(200).json({ success: true, application });
 };
 
@@ -268,6 +271,7 @@ exports.deleteReminder = async (req, res) => {
     if (!application) {
         return res.status(404).json({ success: false, error: 'Application not found' });
     }
+    await invalidatePattern(`applications:${req.user._id.toString()}`).catch(() => {});
     res.status(200).json({ success: true, application });
 };
 

--- a/backend/controllers/calendar.controller.js
+++ b/backend/controllers/calendar.controller.js
@@ -1,5 +1,4 @@
 const Task = require('../models/Task');
-const { getOrSet } = require('../lib/cache');
 
 // ============================================================
 // CALENDAR CONTROLLER
@@ -66,7 +65,7 @@ exports.getCalendar = async (req, res) => {
         return { days, overdue };
     };
 
-    const { days, overdue } = await getOrSet(cacheKey, 30, fetchCalendar);
+    const { days, overdue } = await fetchCalendar();
 
     res.status(200).json({
         success: true,

--- a/backend/controllers/conversations.controller.js
+++ b/backend/controllers/conversations.controller.js
@@ -3,7 +3,7 @@ const Message = require('../models/Message');
 const Friendship = require('../models/Friendship');
 const { getIO } = require('../lib/socket');
 const posthog = require('../lib/posthog');
-const { getOrSet, invalidatePattern } = require('../lib/cache');
+const { invalidatePattern } = require('../lib/cache');
 
 // ============================================================
 // CONVERSATIONS CONTROLLER
@@ -111,9 +111,7 @@ exports.getConversations = async (req, res) => {
     };
 
     // Search queries bypass cache (dynamic); non-search uses 30s cache per user
-    const conversations = search
-        ? await fetchConversations()
-        : await getOrSet(`conversations:${userId.toString()}`, 30, fetchConversations);
+    const conversations = await fetchConversations();
 
     res.status(200).json({ success: true, conversations });
 };

--- a/backend/controllers/flashcardSets.controller.js
+++ b/backend/controllers/flashcardSets.controller.js
@@ -257,6 +257,8 @@ exports.duplicateSet = async (req, res) => {
         options: { sort: { order: 1 } },
     });
 
+    await invalidatePattern(`flashcardSets:${req.user._id.toString()}`).catch(() => {});
+
     res.status(201).json({ success: true, set: populatedCopy });
 };
 
@@ -290,6 +292,8 @@ exports.updateSet = async (req, res) => {
     if (!set) {
         return res.status(404).json({ success: false, error: 'Flashcard set not found' });
     }
+
+    await invalidatePattern(`flashcardSets:${req.user._id.toString()}`).catch(() => {});
 
     res.status(200).json({ success: true, set });
 };
@@ -328,6 +332,8 @@ exports.addCard = async (req, res) => {
     // Increment totalCards on the set
     await FlashcardSet.findByIdAndUpdate(set._id, { $inc: { totalCards: 1 } });
 
+    await invalidatePattern(`flashcardSets:${req.user._id.toString()}`).catch(() => {});
+
     res.status(201).json({ success: true, card });
 };
 
@@ -363,6 +369,8 @@ exports.updateCard = async (req, res) => {
     if (!card) {
         return res.status(404).json({ success: false, error: 'Flashcard not found' });
     }
+
+    await invalidatePattern(`flashcardSets:${req.user._id.toString()}`).catch(() => {});
 
     res.status(200).json({ success: true, card });
 };
@@ -677,6 +685,8 @@ exports.deleteCard = async (req, res) => {
 
     // Keep totalCards accurate
     await FlashcardSet.findByIdAndUpdate(set._id, { $inc: { totalCards: -1 } });
+
+    await invalidatePattern(`flashcardSets:${req.user._id.toString()}`).catch(() => {});
 
     res.status(200).json({ success: true, message: 'Flashcard deleted' });
 };

--- a/backend/controllers/flashcardSets.controller.js
+++ b/backend/controllers/flashcardSets.controller.js
@@ -6,7 +6,7 @@ const posthog = require('../lib/posthog');
 const { createActivity, createShareActivities } = require('../services/activity.service');
 const { getIO } = require('../lib/socket');
 const { sendShareMessage } = require('../services/share.service');
-const { getOrSet, invalidate, invalidatePattern } = require('../lib/cache');
+const { invalidate, invalidatePattern } = require('../lib/cache');
 
 // ============================================================
 // FLASHCARD SETS CONTROLLER
@@ -106,9 +106,7 @@ exports.getSets = async (req, res) => {
         return { sets, pagination: { total, page: Number(page), limit: Number(limit), pages: Math.ceil(total / Number(limit)) } };
     };
 
-    const result = search
-        ? await fetchSets()
-        : await getOrSet(cacheKey, 60, fetchSets);
+    const result = await fetchSets();
 
     res.status(200).json({ success: true, ...result });
 };
@@ -650,9 +648,7 @@ exports.getSharedSets = async (req, res) => {
         return { sets };
     };
 
-    const result = !search
-        ? await getOrSet(`shared-sets:${userId}`, 60, fetchSets)
-        : await fetchSets();
+    const result = await fetchSets();
 
     res.status(200).json({ success: true, ...result });
 };

--- a/backend/controllers/friends.controller.js
+++ b/backend/controllers/friends.controller.js
@@ -2,7 +2,7 @@ const Friendship = require('../models/Friendship');
 const User = require('../models/User');
 const { getIO } = require('../lib/socket');
 const posthog = require('../lib/posthog');
-const { getOrSet, invalidatePattern } = require('../lib/cache');
+const { invalidatePattern } = require('../lib/cache');
 
 // ============================================================
 // FRIENDS CONTROLLER
@@ -179,9 +179,7 @@ exports.getFriends = async (req, res) => {
         .populate('user2', 'username firstName lastName avatarUrl roles')
         .sort({ updatedAt: -1 });
 
-    const friendships = search
-        ? await fetchFriends()
-        : await getOrSet(cacheKey, 60, fetchFriends);
+    const friendships = await fetchFriends();
 
     res.status(200).json({ success: true, friends: friendships });
 };

--- a/backend/controllers/messages.controller.js
+++ b/backend/controllers/messages.controller.js
@@ -106,5 +106,7 @@ exports.deleteMessage = async (req, res) => {
         await message.save();
     }
 
+    await invalidatePattern(`conversations:${userId.toString()}`).catch(() => {});
+
     res.status(200).json({ success: true });
 };

--- a/backend/controllers/notes.controller.js
+++ b/backend/controllers/notes.controller.js
@@ -1,6 +1,6 @@
 const Note = require('../models/Note');
 const { getIO } = require('../lib/socket');
-const { getOrSet, invalidate, invalidatePattern } = require('../lib/cache');
+const { invalidate, invalidatePattern } = require('../lib/cache');
 const FlashcardSet = require('../models/FlashcardSet');
 const Flashcard = require('../models/Flashcard');
 const Friendship = require('../models/Friendship');
@@ -249,9 +249,7 @@ exports.getNotes = async (req, res) => {
         return { notes, pagination: { total, page: Number(page), limit: Number(limit), pages: Math.ceil(total / Number(limit)) } };
     };
 
-    const result = search
-        ? await fetchNotes()
-        : await getOrSet(cacheKey, 60, fetchNotes);
+    const result = await fetchNotes();
 
     res.status(200).json({ success: true, ...result });
 };
@@ -829,9 +827,7 @@ exports.getSharedNotes = async (req, res) => {
         return { notes };
     };
 
-    const result = !search
-        ? await getOrSet(`shared-notes:${userId}`, 60, fetchNotes)
-        : await fetchNotes();
+    const result = await fetchNotes();
 
     res.status(200).json({ success: true, ...result });
 };

--- a/backend/controllers/notes.controller.js
+++ b/backend/controllers/notes.controller.js
@@ -141,6 +141,8 @@ exports.uploadNote = async (req, res) => {
 
     posthog.capture(req.user, 'note_created', { platform: 'web', source: getNoteSource(note) });
 
+    await invalidatePattern(`notes:${req.user._id.toString()}`).catch(() => {});
+
     res.status(201).json({ success: true, note });
 };
 
@@ -432,8 +434,9 @@ exports.importNote = async (req, res) => {
     });
 
     posthog.capture(req.user, 'note_created', { platform: 'web', source: getNoteSource(note) });
-
     posthog.capture(req.user, 'google_doc_imported', { noteId: note._id.toString() });
+
+    await invalidatePattern(`notes:${req.user._id.toString()}`).catch(() => {});
 
     res.status(201).json({ success: true, note });
 };
@@ -486,6 +489,9 @@ exports.refreshNote = async (req, res) => {
         { content, pdfUrl: cloudinaryResult.secure_url, pdfPublicId: cloudinaryResult.public_id, lastSyncedAt: new Date() },
         { new: true }
     );
+
+    const refreshAffectedIds = [req.user._id.toString(), ...(note.sharedWith || []).map(id => id.toString())];
+    await Promise.all(refreshAffectedIds.map(id => invalidatePattern(`notes:${id}`))).catch(() => {});
 
     res.status(200).json({ success: true, note: updatedNote });
 };

--- a/backend/controllers/sync.controller.js
+++ b/backend/controllers/sync.controller.js
@@ -4,6 +4,7 @@ const Task = require('../models/Task');
 const Flashcard = require('../models/Flashcard');
 const FlashcardSet = require('../models/FlashcardSet');
 const Message = require('../models/Message');
+const { invalidatePattern } = require('../lib/cache');
 
 // ============================================================
 // SYNC CONTROLLER
@@ -188,6 +189,13 @@ exports.processSync = async (req, res) => {
             if (operation === 'create') await handler.create(req.user._id, documentId, data);
             else if (operation === 'update') await handler.update(req.user._id, documentId, data);
             else if (operation === 'delete') await handler.delete(req.user._id, documentId);
+
+            // Invalidate the relevant cache so subsequent reads reflect the synced change
+            const userId = req.user._id.toString();
+            if (collection === 'notes') await invalidatePattern(`notes:${userId}`).catch(() => {});
+            else if (collection === 'tasks') await invalidatePattern(`tasks:${userId}`).catch(() => {});
+            else if (collection === 'flashcards') await invalidatePattern(`flashcardSets:${userId}`).catch(() => {});
+            else if (collection === 'messages') await invalidatePattern(`conversations:${userId}`).catch(() => {});
 
             await SyncQueue.findByIdAndUpdate(entry._id, {
                 status: 'completed',

--- a/backend/controllers/tasks.controller.js
+++ b/backend/controllers/tasks.controller.js
@@ -443,6 +443,7 @@ exports.updateParticipantStatus = async (req, res) => {
 
     await task.save();
     emitTaskUpdate(task, req.user._id);
+    await invalidateSharedTasksCache(task);
 
     res.status(200).json({ success: true, task });
 };

--- a/backend/controllers/tasks.controller.js
+++ b/backend/controllers/tasks.controller.js
@@ -3,7 +3,7 @@ const Friendship = require('../models/Friendship');
 const { createActivity, createShareActivities } = require('../services/activity.service');
 const { sendShareMessage } = require('../services/share.service');
 const { getIO } = require('../lib/socket');
-const { getOrSet, invalidate, invalidatePattern } = require('../lib/cache');
+const { invalidate, invalidatePattern } = require('../lib/cache');
 const posthog = require('../lib/posthog');
 
 // Emit an event to all task participants/owner except the actor
@@ -183,10 +183,7 @@ exports.getTasks = async (req, res) => {
     };
 
     // Bypass cache when filtering by date range, type, or priority (too many variants)
-    const bypassCache = !!(search || startDate || endDate || type || priority);
-    const result = bypassCache
-        ? await fetchTasks()
-        : await getOrSet(cacheKey, 30, fetchTasks);
+    const result = await fetchTasks();
 
     res.status(200).json({ success: true, ...result });
 };
@@ -331,9 +328,7 @@ exports.getSharedTasks = async (req, res) => {
         return { tasks };
     };
 
-    const result = !search
-        ? await getOrSet(`shared-tasks:${userId}`, 60, fetchTasks)
-        : await fetchTasks();
+    const result = await fetchTasks();
 
     res.status(200).json({ success: true, ...result });
 };

--- a/docs/backend/backend_architecture.md
+++ b/docs/backend/backend_architecture.md
@@ -69,7 +69,7 @@ backend/
 │   ├── sync.routes.js            # /api/sync (stretch)
 │   └── activity.routes.js        # /api/activity (stretch)
 ├── lib/
-│   ├── cache.js                  # getOrSet / invalidate / invalidatePattern — Redis read-through cache with fail-open
+│   ├── cache.js                  # invalidate / invalidatePattern — Redis client (JWT revocation + AI rate limiting only)
 │   ├── socket.js                 # Socket.io init + getIO() singleton
 │   ├── posthog.js                # PostHog server-side capture wrapper (skips demo/seed users)
 │   └── logger.js                 # Pino logger
@@ -421,11 +421,70 @@ npm install cloudinary multer
 
 ---
 
+## Redis
+
+Redis is used for two things only — JWT revocation and per-user AI rate limiting. It is **not** used for list/CRUD caching (removed — MongoDB is fast enough at this scale and caching was causing stale data bugs).
+
+### What Redis does
+
+| Purpose | Key pattern | TTL |
+|---------|-------------|-----|
+| Revoked JWT sessions | `revoked_session:{sessionId}` | Matches JWT expiry |
+| AI rate limiting | `ai:{type}:{userId}:{date}` | 24 hours |
+
+If Redis is unavailable, both fail open — the app continues to work, rate limiting is just skipped.
+
+### Running Redis locally
+
+Redis is required locally if you want AI rate limiting to work. Without it the app still runs — rate limits are just not enforced.
+
+**Check if Redis is installed:**
+```bash
+redis-server --version
+```
+
+**Install via Homebrew (Mac):**
+```bash
+brew install redis
+```
+
+**Start Redis (runs in the background, survives restarts):**
+```bash
+brew services start redis
+```
+
+**Verify it's up:**
+```bash
+redis-cli ping   # should print: PONG
+```
+
+**Stop Redis:**
+```bash
+brew services stop redis
+```
+
+**Then set in `backend/.env`:**
+```
+REDIS_URL=redis://localhost:6379
+```
+
+**Check status anytime:**
+```bash
+brew services info redis
+```
+
+### Production
+
+Redis is provisioned as an add-on in Railway/Render. The platform injects `REDIS_URL` automatically — no manual configuration needed.
+
+---
+
 ## Third-Party Services Summary
 
 | Service | Purpose | Env Vars | When Needed |
 |---------|---------|----------|-------------|
 | MongoDB Atlas | Database | `MONGODB_URI` | Session 1 (ready) |
+| Redis | JWT revocation + AI rate limiting | `REDIS_URL` | Optional locally; required in prod |
 | Cloudinary | Resume PDF storage | `CLOUDINARY_*` | Session 2 (DB-8) / Session 5 (API-16) |
 | Google OAuth | Authentication + Drive/Docs linking | `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET` | Session 3 (API-2) |
 | Google Drive API | Note import | Uses Google OAuth tokens | Session 3 (API-5) |

--- a/web/src/pages/Calendar.jsx
+++ b/web/src/pages/Calendar.jsx
@@ -494,8 +494,10 @@ export default function Calendar() {
         open={!!viewingTaskId}
         onClose={() => setViewingTaskId(null)}
         onUpdated={() => {
-          queryClient.invalidateQueries({ queryKey: ['tasks'] });
-          queryClient.invalidateQueries({ queryKey: ['calendar'] });
+          queryClient.invalidateQueries({ queryKey: ['tasks'], refetchType: 'all' });
+          queryClient.invalidateQueries({ queryKey: ['tasks-count'], refetchType: 'all' });
+          queryClient.invalidateQueries({ queryKey: ['tasks-dashboard-display'], refetchType: 'all' });
+          queryClient.invalidateQueries({ queryKey: ['calendar'], refetchType: 'all' });
         }}
       />
     </div>

--- a/web/src/pages/applications/ApplicationsList.jsx
+++ b/web/src/pages/applications/ApplicationsList.jsx
@@ -77,9 +77,23 @@ export default function ApplicationsList() {
 
   const createMutation = useMutation({
     mutationFn: (payload) => api.post('/applications', payload),
-    onSuccess: () => {
+    onSuccess: (data) => {
       posthog.capture('job_application_created', { platform: 'web' });
-      invalidateApps();
+      const application = data?.application;
+      if (application) {
+        queryClient.setQueryData(['applications', { search, status: stageFilter }], (old) => {
+          if (!old?.applications) return old;
+          return {
+            ...old,
+            applications: [application, ...old.applications],
+            pagination: old.pagination
+              ? { ...old.pagination, total: old.pagination.total + 1 }
+              : old.pagination,
+          };
+        });
+      }
+      queryClient.invalidateQueries({ queryKey: ['applications'], refetchType: 'all' });
+      queryClient.invalidateQueries({ queryKey: ['applications-dashboard'], refetchType: 'all' });
       setShowCreate(false);
       setForm(emptyForm);
     },

--- a/web/src/pages/flashcards/FlashcardSets.jsx
+++ b/web/src/pages/flashcards/FlashcardSets.jsx
@@ -41,7 +41,6 @@ export default function FlashcardSets() {
       const p = lastPage?.pagination;
       return p && p.page < p.pages ? p.page + 1 : undefined;
     },
-    staleTime: 120_000,
     placeholderData: (prev) => prev,
     enabled: !sharedTab,
   });
@@ -50,7 +49,6 @@ export default function FlashcardSets() {
     queryKey: ['flashcard-sets-shared', search],
     queryFn: () =>
       api.get('/flashcard-sets/shared', { params: search ? { search } : {} }).then(r => r.data),
-    staleTime: 120_000,
     placeholderData: (prev) => prev,
     enabled: sharedTab,
   });

--- a/web/src/pages/flashcards/FlashcardSets.jsx
+++ b/web/src/pages/flashcards/FlashcardSets.jsx
@@ -59,8 +59,24 @@ export default function FlashcardSets() {
 
   const createMutation = useMutation({
     mutationFn: (payload) => api.post('/flashcard-sets', payload),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['flashcard-sets'] });
+    onSuccess: (data) => {
+      const set = data?.set;
+      if (set) {
+        queryClient.setQueryData(['flashcard-sets', search], (old) => {
+          if (!old?.pages?.length) return old;
+          return {
+            ...old,
+            pages: [{
+              ...old.pages[0],
+              sets: [set, ...old.pages[0].sets],
+              pagination: old.pages[0].pagination
+                ? { ...old.pages[0].pagination, total: old.pages[0].pagination.total + 1 }
+                : old.pages[0].pagination,
+            }, ...old.pages.slice(1)],
+          };
+        });
+      }
+      queryClient.invalidateQueries({ queryKey: ['flashcard-sets'], refetchType: 'all' });
       setShowCreate(false);
       setNewSet({ title: '', description: '', subject: '' });
     },

--- a/web/src/pages/notes/NoteDetail.jsx
+++ b/web/src/pages/notes/NoteDetail.jsx
@@ -59,7 +59,7 @@ export default function NoteDetail() {
   const deleteMutation = useMutation({
     mutationFn: () => api.delete(`/notes/${id}`),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['notes'] });
+      queryClient.invalidateQueries({ queryKey: ['notes'], refetchType: 'all' });
       navigate('/notes');
     },
   });

--- a/web/src/pages/notes/NotesList.jsx
+++ b/web/src/pages/notes/NotesList.jsx
@@ -104,36 +104,64 @@ export default function NotesList() {
     onSettled: () => queryClient.invalidateQueries({ queryKey: ['notes'] }),
   });
 
+  const insertOptimisticNote = (tempNote) => {
+    queryClient.setQueryData(['notes', { search, type }], (old) => {
+      if (!old?.pages?.length) return old;
+      return {
+        ...old,
+        pages: [{
+          ...old.pages[0],
+          notes: [tempNote, ...old.pages[0].notes],
+          pagination: old.pages[0].pagination
+            ? { ...old.pages[0].pagination, total: old.pages[0].pagination.total + 1 }
+            : old.pages[0].pagination,
+        }, ...old.pages.slice(1)],
+      };
+    });
+  };
+
+  const replaceOptimisticNote = (tempId, realNote) => {
+    queryClient.setQueryData(['notes', { search, type }], (old) => {
+      if (!old?.pages?.length) return old;
+      return {
+        ...old,
+        pages: old.pages.map((page) => ({
+          ...page,
+          notes: page.notes.map((n) => (n._id === tempId ? realNote : n)),
+        })),
+      };
+    });
+  };
+
   const importMutation = useMutation({
     mutationFn: (payload) => api.post('/notes/import', payload),
-    onSuccess: (data) => {
-      const note = data?.note;
-      if (note) {
-        // Insert immediately so the note appears before the background refetch resolves.
-        // Bypasses the window-focus refetch race that fires when Google Picker closes.
-        queryClient.setQueryData(['notes', { search, type }], (old) => {
-          if (!old?.pages?.length) return old;
-          return {
-            ...old,
-            pages: [
-              {
-                ...old.pages[0],
-                notes: [note, ...old.pages[0].notes],
-                pagination: old.pages[0].pagination
-                  ? { ...old.pages[0].pagination, total: old.pages[0].pagination.total + 1 }
-                  : old.pages[0].pagination,
-              },
-              ...old.pages.slice(1),
-            ],
-          };
-        });
-      }
-      queryClient.invalidateQueries({ queryKey: ['notes'], refetchType: 'all' });
+    onMutate: async (payload) => {
+      await queryClient.cancelQueries({ queryKey: ['notes'] });
+      const prev = queryClient.getQueryData(['notes', { search, type }]);
+      const tempId = `optimistic-${Date.now()}`;
+      insertOptimisticNote({
+        _id: tempId,
+        title: payload.title || 'Importing…',
+        type: 'general',
+        tags: [],
+        isPinned: false,
+        createdAt: new Date().toISOString(),
+        lastViewedAt: new Date().toISOString(),
+        _isOptimistic: true,
+      });
       setShowImport(false);
       setSelectedFile(null);
       setImportError('');
+      return { prev, tempId };
     },
-    onError: (err) => {
+    onSuccess: (data, _vars, ctx) => {
+      const note = data?.note;
+      if (note && ctx?.tempId) replaceOptimisticNote(ctx.tempId, note);
+      queryClient.invalidateQueries({ queryKey: ['notes'], refetchType: 'all' });
+    },
+    onError: (err, _vars, ctx) => {
+      if (ctx?.prev) queryClient.setQueryData(['notes', { search, type }], ctx.prev);
+      setShowImport(true);
       setImportError(err.response?.data?.error || 'Import failed.');
     },
   });
@@ -145,33 +173,34 @@ export default function NotesList() {
       if (title) form.append('title', title);
       return api.post('/notes/upload', form, { headers: { 'Content-Type': 'multipart/form-data' } });
     },
-    onSuccess: (data) => {
-      const note = data?.note;
-      if (note) {
-        queryClient.setQueryData(['notes', { search, type }], (old) => {
-          if (!old?.pages?.length) return old;
-          return {
-            ...old,
-            pages: [
-              {
-                ...old.pages[0],
-                notes: [note, ...old.pages[0].notes],
-                pagination: old.pages[0].pagination
-                  ? { ...old.pages[0].pagination, total: old.pages[0].pagination.total + 1 }
-                  : old.pages[0].pagination,
-              },
-              ...old.pages.slice(1),
-            ],
-          };
-        });
-      }
-      queryClient.invalidateQueries({ queryKey: ['notes'], refetchType: 'all' });
+    onMutate: async ({ file, title }) => {
+      await queryClient.cancelQueries({ queryKey: ['notes'] });
+      const prev = queryClient.getQueryData(['notes', { search, type }]);
+      const tempId = `optimistic-${Date.now()}`;
+      insertOptimisticNote({
+        _id: tempId,
+        title: title || file?.name?.replace(/\.pdf$/i, '') || 'Uploading…',
+        type: 'general',
+        tags: [],
+        isPinned: false,
+        createdAt: new Date().toISOString(),
+        lastViewedAt: new Date().toISOString(),
+        _isOptimistic: true,
+      });
       setShowImport(false);
       setUploadFile(null);
       setUploadTitle('');
       setImportError('');
+      return { prev, tempId };
     },
-    onError: (err) => {
+    onSuccess: (data, _vars, ctx) => {
+      const note = data?.note;
+      if (note && ctx?.tempId) replaceOptimisticNote(ctx.tempId, note);
+      queryClient.invalidateQueries({ queryKey: ['notes'], refetchType: 'all' });
+    },
+    onError: (err, _vars, ctx) => {
+      if (ctx?.prev) queryClient.setQueryData(['notes', { search, type }], ctx.prev);
+      setShowImport(true);
       setImportError(err.response?.data?.error || 'Upload failed.');
     },
   });
@@ -410,7 +439,7 @@ export default function NotesList() {
               <NoteCard
                 key={note._id}
                 note={note}
-                onDelete={sharedTab || user?.isDemo ? null : () => setDeleteConfirm(note._id)}
+                onDelete={sharedTab || user?.isDemo || note._isOptimistic ? null : () => setDeleteConfirm(note._id)}
               />
             ))}
           </div>
@@ -656,6 +685,32 @@ export default function NotesList() {
 }
 
 function NoteCard({ note, onDelete }) {
+  if (note._isOptimistic) {
+    return (
+      <div className="animate-pulse" style={{
+        background: 'white',
+        border: '1px dashed #D8B4FE',
+        borderRadius: 16,
+        padding: '20px',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 10,
+        opacity: 0.7,
+      }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <div style={{ width: 56, height: 20, background: '#F3E8FF', borderRadius: 20 }} />
+          <div style={{ marginLeft: 'auto', width: 16, height: 16, borderRadius: '50%', border: '2px solid #D8B4FE', borderTopColor: '#7C3AED', animation: 'spin 0.8s linear infinite' }} />
+        </div>
+        <div style={{ height: 16, background: '#F3E8FF', borderRadius: 6, width: '70%' }} />
+        <div style={{ height: 12, background: '#F9F5FF', borderRadius: 6, width: '90%' }} />
+        <div style={{ height: 12, background: '#F9F5FF', borderRadius: 6, width: '60%' }} />
+        <div style={{ marginTop: 4, fontSize: '0.75rem', color: '#7C3AED', fontWeight: 500 }}>
+          {note.title}
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div
       className="group"

--- a/web/src/pages/notes/NotesList.jsx
+++ b/web/src/pages/notes/NotesList.jsx
@@ -61,7 +61,6 @@ export default function NotesList() {
       const p = lastPage?.pagination;
       return p && p.page < p.pages ? p.page + 1 : undefined;
     },
-    staleTime: 60_000,
     placeholderData: (prev) => prev,
     enabled: !sharedTab,
   });
@@ -73,7 +72,6 @@ export default function NotesList() {
       api.get('/notes/shared', {
         params: { ...(sharedSearch && { search: sharedSearch }) },
       }).then(r => r.data),
-    staleTime: 60_000,
     placeholderData: (prev) => prev,
     enabled: sharedTab,
   });

--- a/web/src/pages/notes/NotesList.jsx
+++ b/web/src/pages/notes/NotesList.jsx
@@ -106,8 +106,29 @@ export default function NotesList() {
 
   const importMutation = useMutation({
     mutationFn: (payload) => api.post('/notes/import', payload),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['notes'] });
+    onSuccess: (data) => {
+      const note = data?.note;
+      if (note) {
+        // Insert immediately so the note appears before the background refetch resolves.
+        // Bypasses the window-focus refetch race that fires when Google Picker closes.
+        queryClient.setQueryData(['notes', { search, type }], (old) => {
+          if (!old?.pages?.length) return old;
+          return {
+            ...old,
+            pages: [
+              {
+                ...old.pages[0],
+                notes: [note, ...old.pages[0].notes],
+                pagination: old.pages[0].pagination
+                  ? { ...old.pages[0].pagination, total: old.pages[0].pagination.total + 1 }
+                  : old.pages[0].pagination,
+              },
+              ...old.pages.slice(1),
+            ],
+          };
+        });
+      }
+      queryClient.invalidateQueries({ queryKey: ['notes'], refetchType: 'all' });
       setShowImport(false);
       setSelectedFile(null);
       setImportError('');
@@ -124,8 +145,27 @@ export default function NotesList() {
       if (title) form.append('title', title);
       return api.post('/notes/upload', form, { headers: { 'Content-Type': 'multipart/form-data' } });
     },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['notes'] });
+    onSuccess: (data) => {
+      const note = data?.note;
+      if (note) {
+        queryClient.setQueryData(['notes', { search, type }], (old) => {
+          if (!old?.pages?.length) return old;
+          return {
+            ...old,
+            pages: [
+              {
+                ...old.pages[0],
+                notes: [note, ...old.pages[0].notes],
+                pagination: old.pages[0].pagination
+                  ? { ...old.pages[0].pagination, total: old.pages[0].pagination.total + 1 }
+                  : old.pages[0].pagination,
+              },
+              ...old.pages.slice(1),
+            ],
+          };
+        });
+      }
+      queryClient.invalidateQueries({ queryKey: ['notes'], refetchType: 'all' });
       setShowImport(false);
       setUploadFile(null);
       setUploadTitle('');

--- a/web/src/pages/tasks/Tasks.jsx
+++ b/web/src/pages/tasks/Tasks.jsx
@@ -113,9 +113,27 @@ export default function Tasks() {
 
   const createMutation = useMutation({
     mutationFn: (payload) => api.post('/tasks', payload),
-    onSuccess: () => {
+    onSuccess: (data) => {
       posthog.capture('task_created', { platform: 'web' });
-      invalidateTasks();
+      const task = data?.task;
+      if (task) {
+        queryClient.setQueryData(['tasks', 'mine', search], (old) => {
+          if (!old?.pages?.length) return old;
+          return {
+            ...old,
+            pages: [{
+              ...old.pages[0],
+              tasks: [task, ...old.pages[0].tasks],
+              pagination: old.pages[0].pagination
+                ? { ...old.pages[0].pagination, total: old.pages[0].pagination.total + 1 }
+                : old.pages[0].pagination,
+            }, ...old.pages.slice(1)],
+          };
+        });
+      }
+      queryClient.invalidateQueries({ queryKey: ['tasks'], refetchType: 'all' });
+      queryClient.invalidateQueries({ queryKey: ['calendar'], refetchType: 'all' });
+      queryClient.invalidateQueries({ queryKey: ['activity'], refetchType: 'all' });
       setShowCreate(false);
       setForm(emptyForm);
     },

--- a/web/src/pages/tasks/Tasks.jsx
+++ b/web/src/pages/tasks/Tasks.jsx
@@ -106,9 +106,11 @@ export default function Tasks() {
     : (ownData?.pages.flatMap(p => p.tasks) ?? []);
 
   const invalidateTasks = () => {
-    queryClient.invalidateQueries({ queryKey: ['tasks'] });
-    queryClient.invalidateQueries({ queryKey: ['calendar'] });
-    queryClient.invalidateQueries({ queryKey: ['activity'] });
+    queryClient.invalidateQueries({ queryKey: ['tasks'], refetchType: 'all' });
+    queryClient.invalidateQueries({ queryKey: ['tasks-count'], refetchType: 'all' });
+    queryClient.invalidateQueries({ queryKey: ['tasks-dashboard-display'], refetchType: 'all' });
+    queryClient.invalidateQueries({ queryKey: ['calendar'], refetchType: 'all' });
+    queryClient.invalidateQueries({ queryKey: ['activity'], refetchType: 'all' });
   };
 
   const createMutation = useMutation({
@@ -132,6 +134,8 @@ export default function Tasks() {
         });
       }
       queryClient.invalidateQueries({ queryKey: ['tasks'], refetchType: 'all' });
+      queryClient.invalidateQueries({ queryKey: ['tasks-count'], refetchType: 'all' });
+      queryClient.invalidateQueries({ queryKey: ['tasks-dashboard-display'], refetchType: 'all' });
       queryClient.invalidateQueries({ queryKey: ['calendar'], refetchType: 'all' });
       queryClient.invalidateQueries({ queryKey: ['activity'], refetchType: 'all' });
       setShowCreate(false);


### PR DESCRIPTION
## Problem
Redis list caching (60s TTL) was making things worse, not better. For a personal-scale app with frequent mutations, the cache hit rate was low and every mutation had to invalidate the cache — adding overhead with no meaningful benefit. The net result was stale data across the entire app, and a system that was harder to reason about than plain MongoDB reads.

Additionally, 23 mutation endpoints were missing cache invalidation entirely, and frontend query key mismatches meant the dashboard task counts were never updated after mutations.

## What changed

### Backend — removed Redis list caching
- Stripped `getOrSet` from all 8 CRUD controllers: notes, tasks, flashcard sets, applications, friends, conversations, calendar, activity
- Every read now hits MongoDB directly — always fresh, no stale window
- Redis kept for JWT revocation and AI rate limiting (the two cases where it's genuinely the right tool)
- `invalidatePattern` calls left in place (harmless no-ops now, useful if selective caching is reintroduced)

### Backend — fixed missing cache invalidation (23 endpoints)
- `importNote`, `uploadNote`, `refreshNote` — were creating/updating notes without clearing cache
- `duplicateSet`, `updateSet`, `addCard`, `updateCard`, `deleteCard` — same for flashcard sets
- `updateParticipantStatus` (tasks), `addContact`, `addReminder`, `deleteContact`, `deleteReminder` (applications)
- `deleteMessage`, all 9 offline sync handlers in `sync.controller`

### Frontend — instant UI updates
- `importMutation` and `uploadMutation` in NotesList: moved from `onSuccess` to `onMutate` — placeholder card appears the moment the user confirms import, before the Google Drive + Cloudinary round-trip completes
- `createMutation` for tasks, flashcard sets, applications: `setQueryData` in `onSuccess` inserts the new item at the top of the list immediately
- `deleteMutation` in NoteDetail: `refetchType: 'all'` so dashboard count updates even when unmounted

### Frontend — fixed dashboard task counts never updating
- `invalidateTasks()` only matched `['tasks', ...]` keys — the dashboard uses `['tasks-count', 'todo']` and `['tasks-dashboard-display']`, which have different first elements and were never matched
- Added both keys to `invalidateTasks()` and `createMutation` with `refetchType: 'all'`
- Same fix applied to Calendar's `onUpdated` callback

### Frontend — removed staleTime values matched to Redis TTL
- Removed `staleTime: 60_000` from NotesList (was matched to the 60s Redis TTL)
- Removed `staleTime: 120_000` from FlashcardSets (was matched to the 120s Redis TTL)

### Android
- `CareerRepository.createApplication`: added `appDao.insert()` before returning so the cache-first `getApplicationsFlow` emission includes the new application immediately, matching the pattern already used by `createTask` and `createSet`