### PR TITLE
fix: onboarding enforcement and Google OAuth tab fix (web + Android)

### DIFF
--- a/android/app/src/main/java/com/continuum/android/core/ui/navigation/AppNavHost.kt
+++ b/android/app/src/main/java/com/continuum/android/core/ui/navigation/AppNavHost.kt
@@ -256,6 +256,17 @@ fun AppNavHost(
         else navProfileViewModel.clear()
     }
 
+    LaunchedEffect(navProfile.isLoaded, navProfile.onboardingCompleted, navProfile.tourCompleted) {
+        if (isAuthenticated && navProfile.isLoaded &&
+            (!navProfile.onboardingCompleted || !navProfile.tourCompleted) &&
+            !navProfile.isDemo
+        ) {
+            navController.navigate(NavRoutes.Onboarding.ROOT) {
+                popUpTo(0) { inclusive = true }
+            }
+        }
+    }
+
     // Logo tap: navigate to Dashboard from any tab screen
     val onLogoClick: () -> Unit = {
         navController.navigate(NavRoutes.Dashboard.ROOT) {

--- a/android/app/src/main/java/com/continuum/android/feature/onboarding/presentation/steps/IntegrationsStep.kt
+++ b/android/app/src/main/java/com/continuum/android/feature/onboarding/presentation/steps/IntegrationsStep.kt
@@ -13,11 +13,12 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.core.net.toUri
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LifecycleEventEffect
 import com.continuum.android.core.ui.components.ContinuumButton
 import com.continuum.android.core.ui.theme.*
 import com.continuum.android.feature.profile.data.repository.ProfileRepository
 import com.continuum.android.feature.profile.domain.Profile
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
 @Composable
@@ -96,17 +97,9 @@ fun IntegrationsStep(
                         onClick = {
                             linking = true
                             val intent = CustomTabsIntent.Builder().build()
-                            intent.launchUrl(context, "$apiBaseUrl/api/auth/google".toUri())
-                            scope.launch {
-                                delay(1_000)
-                                val refreshed = profileRepository.getProfile().getOrNull()
-                                linking = false
-                                if (refreshed?.isGoogleLinked == true) {
-                                    isGoogleConnected = true
-                                    // Don't auto-advance — user manually clicks Continue
-                                    // so they can connect additional integrations first
-                                }
-                            }
+                            // source=linking tells AuthCallback this is a linking flow so it
+                            // shows a 'Connected' screen instead of navigating to onboarding
+                            intent.launchUrl(context, "$apiBaseUrl/api/auth/google?source=linking".toUri())
                         },
                         enabled = !linking,
                         colors = ButtonDefaults.buttonColors(containerColor = BrandPurple),
@@ -124,6 +117,20 @@ fun IntegrationsStep(
         }
 
         // Additional integration cards (Canvas LMS, etc.) slot here
+
+        // Poll the profile when the app returns to foreground (i.e. the CCT closed).
+        // This replaces the old 1-second one-shot delay which fired before OAuth could finish.
+        LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {
+            if (linking) {
+                scope.launch {
+                    val refreshed = profileRepository.getProfile().getOrNull()
+                    linking = false
+                    if (refreshed?.isGoogleLinked == true) {
+                        isGoogleConnected = true
+                    }
+                }
+            }
+        }
 
         Spacer(Modifier.height(20.dp))
         ContinuumButton(

--- a/android/app/src/main/java/com/continuum/android/feature/profile/presentation/NavProfileViewModel.kt
+++ b/android/app/src/main/java/com/continuum/android/feature/profile/presentation/NavProfileViewModel.kt
@@ -16,7 +16,10 @@ import javax.inject.Inject
 data class NavProfileUiState(
     val avatarUrl: String? = null,
     val displayName: String = "Profile",
-    val isDemo: Boolean = false
+    val isDemo: Boolean = false,
+    val onboardingCompleted: Boolean = false,
+    val tourCompleted: Boolean = false,
+    val isLoaded: Boolean = false,
 )
 
 @HiltViewModel
@@ -50,7 +53,10 @@ class NavProfileViewModel @Inject constructor(
                                 .filter { name -> name.isNotBlank() }
                                 .joinToString(" ")
                                 .ifBlank { profile.username.ifBlank { "Profile" } },
-                            isDemo = profile.isDemo
+                            isDemo = profile.isDemo,
+                            onboardingCompleted = profile.onboardingCompleted,
+                            tourCompleted = profile.tourCompleted,
+                            isLoaded = true,
                         )
                     }
                 }

--- a/backend/controllers/auth.controller.js
+++ b/backend/controllers/auth.controller.js
@@ -377,7 +377,10 @@ exports.googleCallback = async (req, res) => {
         expiresAt: new Date(Date.now() + 60 * 1000), // 60 seconds
     });
 
-    res.redirect(`${process.env.FRONTEND_URL}/auth/callback?code=${rawCode}`);
+    const oauthSource = req.cookies?.oauth_source || '';
+    res.clearCookie('oauth_source');
+    const sourcePart = oauthSource === 'linking' ? '&source=linking' : '';
+    res.redirect(`${process.env.FRONTEND_URL}/auth/callback?code=${rawCode}${sourcePart}`);
 };
 
 // ----------------------------------------

--- a/backend/routes/auth.routes.js
+++ b/backend/routes/auth.routes.js
@@ -156,7 +156,12 @@ router.post('/refresh', authLimiter, authController.refresh);
  *       302:
  *         description: Redirect to Google
  */
-router.get('/google', passport.authenticate('google', { session: false, scope: ['profile', 'email', 'https://www.googleapis.com/auth/drive.file'], accessType: 'offline', prompt: 'consent' }));
+router.get('/google', (req, res, next) => {
+    if (req.query.source === 'linking') {
+        res.cookie('oauth_source', 'linking', { httpOnly: true, maxAge: 120_000, sameSite: 'lax' });
+    }
+    passport.authenticate('google', { session: false, scope: ['profile', 'email', 'https://www.googleapis.com/auth/drive.file'], accessType: 'offline', prompt: 'consent' })(req, res, next);
+});
 
 /**
  * @swagger

--- a/docs/future-ideas/continuum-rebrand-research.md
+++ b/docs/future-ideas/continuum-rebrand-research.md
@@ -1,0 +1,134 @@
+# Continuum — Rebrand Name Research
+**Prepared:** May 2026  
+**Status:** Internal reference — Year 1 evaluation  
+**Candidates evaluated:** Kova, Folia, Contin vs. holding Continuum
+
+---
+
+## Summary Verdict
+
+| Name | Syllables | .com Domain | .app Domain | Major Conflicts | Edtech Conflict | Verdict |
+|------|-----------|-------------|-------------|-----------------|-----------------|---------|
+| **Continuum** | 4 | Owned (usecontinuum.dev) | — | None in edtech | None | Hold for now |
+| **Contin** | 2 | Likely available | Likely available | None found | None | Best alternative |
+| **Kova** | 2 | Parked/squatted | Taken (audiobook app) | Trademark registered in US + Canada | None | Risky |
+| **Folia** | 3 | Taken (active app) | Taken (active app) | Direct product overlap | Partial | Hard no |
+
+---
+
+## Candidate 1: Kova
+
+### Availability
+- **kova.com** — parked or held; not actively used by a tech product but not free
+- **kova.app** — taken by Kova, an audiobook creation app (Expressive Voice Assistant Laboratories Inc), live on the App Store
+
+### Trademark Risk
+KOVA is a **registered trademark in both Canada and the United States** held by Expressive Voice Assistant Laboratories Inc for the audiobook app. This is the biggest flag — a USPTO registration in a consumer app category creates real legal exposure if you build brand equity under this name and then try to trademark it yourself later.
+
+### Other Companies Using "Kova"
+- Kova Digital — web/mobile dev agency
+- Kova Builder — venture studio
+- Kova App (Ukraine) — cleaning marketplace
+- Kova App (Hungary) — app publisher
+- KOVA (Vietnam) — paint brand with Google Play app
+
+### Edtech Conflict
+None. No edtech company is using Kova.
+
+### Assessment
+The name sounds clean and hits 2 syllables, but the active US trademark from a consumer app company is a meaningful risk. If you build to scale under this name, a USPTO filing will likely get rejected or challenged. Pursuing it would mean either licensing, litigation, or a forced rebrand at the worst possible time. Not recommended.
+
+---
+
+## Candidate 2: Folia
+
+### Availability
+- **folia.com** — actively taken by Branchfire Inc, makers of iAnnotate and the Folia productivity app
+- **folia.app** — same company, same product
+
+### What Folia (the existing company) Does
+Folia by Branchfire is a document annotation and productivity platform. It lets users organize work into projects, pull files from Google Drive / OneDrive / Dropbox, annotate PDFs and Office documents, and share with collaborators in real time. It is available on iOS, Android, and web.
+
+This is not an incidental name conflict — this is a company doing a meaningfully similar thing to Continuum (document-centric productivity, Google Drive integration, collaboration). The overlap would create constant confusion in search results, app stores, and press.
+
+### Trademark / Legal
+Branchfire (parent company) has been operating since at least 2013 (iAnnotate predates Folia). They have established prior use, active apps on both major app stores, and a funded product with a named CTO. A USPTO filing under "Folia" would almost certainly be rejected given their prior use in the same software category.
+
+### Assessment
+Hard no. Both the domain and the app store presence are owned by a direct partial competitor. No path to acquiring this name without buying the company or litigating it.
+
+---
+
+## Candidate 3: Contin
+
+### What It Is
+A natural 2-syllable shortening of Continuum. Preserves the existing brand story, the "C" logo, and all accumulated brand equity from TEI, the interview brief, and deployed product history.
+
+### Availability
+- **contin.com** — no active tech company found at this domain; likely squatted or lightly held, but acquirable
+- **contin.app** — no active product found; likely available or affordable to acquire
+- **usecontin.dev** — almost certainly available (same pattern as usecontinuum.dev)
+
+### Trademark Conflicts
+No company named "Contin" found in consumer tech, edtech, or adjacent B2C software categories. The only adjacent result is Continu (the enterprise LMS already flagged as a conflict), but "Contin" is a different enough string that it would not be confused with Continu in app store search or trademark filings.
+
+### Edtech Conflict
+None found.
+
+### Key Advantages
+- Directly derived from Continuum — "I use Contin" is a natural shorthand students would actually say
+- Same C logo works unchanged
+- Preserves all GitHub history, pitch framing, and interview talking points ("shortened from Continuum as the product scaled")
+- 2 syllables matches the marketability benchmark (Discord, Notion, Quizlet)
+- No active competitor using the name in consumer software
+
+### Assessment
+Best alternative candidate. If a rebrand happens after Year 1, Contin is the path of least resistance — it costs the least in brand equity while solving the syllable/marketability concern.
+
+---
+
+## Current Name: Continuum
+
+### Why It Still Works Right Now
+- usecontinuum.dev is already owned and deployed
+- Full brand equity built: TEI pitch, GitHub, Swagger docs, interview brief, resume bullets
+- No edtech competitor uses the name
+- The C-in-circle logo renders cleanly on both iOS and Android home screens
+- "Continuum" is descriptive and defensible in interviews ("the unbroken path from classroom to career")
+
+### The Actual Problem
+The home screen label truncates on smaller devices, and the name doesn't shorten to a natural nickname organically. Neither is fatal at current scale.
+
+### When to Revisit
+Per the 5-year roadmap: end of Year 1, before paid marketing begins. Real user feedback from Lehigh campus seeding will tell you whether students are struggling to say or remember the name in practice. If they are, Contin is the move. If they aren't, save the rebrand energy for product.
+
+---
+
+## Competitive Landscape Context
+
+The broader student productivity edtech space for reference:
+
+| Competitor | Category | Syllables | Why Students Use It |
+|------------|----------|-----------|---------------------|
+| Notion | Notes / workspace | 2 | Flexible, aesthetic |
+| Quizlet | Flashcards | 3 | AI study tools, ubiquitous |
+| Discord | Messaging | 2 | Real-time, group-native |
+| Handshake | Career / recruiting | 2 | Campus recruiting standard |
+| Canvas | LMS | 2 | Institutional mandated |
+| Google Docs | Notes | 3 (Google) | Default, frictionless |
+
+Continuum competes across all of these simultaneously, which is the pitch. No single competitor occupies the same unified space. The name doesn't need to beat Quizlet on memorability — it needs to be distinct enough that students who hear it once can find it in the App Store.
+
+---
+
+## Recommendation
+
+**Do nothing now.** Hold Continuum through graduation, TEI, and the first campus growth cycle.
+
+**If rebrand in Year 1:** Go with **Contin**. It is the only candidate with no active conflicts, no trademark risk, clean domain availability, and a direct inheritance path from the existing brand. Every other candidate on this list has a meaningful blocker.
+
+**Do not pursue Folia or Kova.** Folia is actively taken by a partial competitor. Kova carries a live US trademark from a consumer app company.
+
+---
+
+*Research conducted May 2026. Domain and trademark status should be re-verified at time of any formal rebrand decision. USPTO trademark search recommended before any filing.*

--- a/web/src/components/layout/AppLayout.jsx
+++ b/web/src/components/layout/AppLayout.jsx
@@ -49,6 +49,12 @@ export default function AppLayout() {
     return <Navigate to="/login" replace />;
   }
 
+  if (!user.onboardingCompleted || !user.tourCompleted) {
+    if (!user.isDemo && !user.isSeedUser) {
+      return <Navigate to="/onboarding" replace />;
+    }
+  }
+
   // OnboardingModal is now only used for the replay/finish-setup paths triggered from Profile.
   // Fresh-signup onboarding happens on the dedicated /onboarding route (no AppLayout chrome).
   const isReplay = forceOnboardingOpen && !!user?.onboardingCompleted;

--- a/web/src/components/onboarding/steps/IntegrationsStep.jsx
+++ b/web/src/components/onboarding/steps/IntegrationsStep.jsx
@@ -63,11 +63,33 @@ export default function IntegrationsStep({ onContinue, onSkip }) {
   const handleConnectGoogle = () => {
     setLinking(true);
     const apiBase = import.meta.env.VITE_API_URL || 'http://localhost:5001';
-    const popup = window.open(`${apiBase}/api/auth/google`, 'google-oauth', 'width=500,height=640');
 
+    // BroadcastChannel receives the success message from AuthCallback regardless of
+    // whether the browser opened a popup or a new tab (window.opener is unreliable
+    // after cross-origin OAuth redirects through Google's servers).
+    const channel = new BroadcastChannel('continuum_oauth');
+    channel.onmessage = (e) => {
+      if (e.data.type === 'GOOGLE_OAUTH_SUCCESS' && e.data.googleId) {
+        channel.close();
+        setLinking(false);
+        updateUser({ googleId: e.data.googleId });
+        try {
+          posthog.capture('integration_connected', {
+            platform: 'web',
+            integration: 'google_drive',
+            connected_during: 'onboarding',
+          });
+        } catch (_) {}
+      }
+    };
+
+    const popup = window.open(`${apiBase}/api/auth/google?source=linking`, 'google-oauth', 'width=500,height=640');
+
+    // Keep polling popup.closed as a fallback for when window.close() works normally
     const poll = setInterval(async () => {
       if (!popup || popup.closed) {
         clearInterval(poll);
+        channel.close();
         setLinking(false);
         try {
           const res = await api.get('/auth/me');
@@ -81,12 +103,16 @@ export default function IntegrationsStep({ onContinue, onSkip }) {
                 connected_during: 'onboarding',
               });
             } catch (_) {}
-            // Don't auto-advance — user manually clicks Continue
-            // so they can connect additional integrations first
           }
         } catch (_) {}
       }
     }, 500);
+
+    // Clean up channel and poll if the component unmounts mid-flow
+    return () => {
+      clearInterval(poll);
+      channel.close();
+    };
   };
 
   return (

--- a/web/src/pages/auth/AuthCallback.jsx
+++ b/web/src/pages/auth/AuthCallback.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useAuth } from '@/context/AuthContext';
 import api from '@/lib/api';
@@ -11,6 +11,7 @@ export default function AuthCallback() {
   const navigate = useNavigate();
   const { updateUser } = useAuth();
   const processed = useRef(false);
+  const [showConnected, setShowConnected] = useState(false);
 
   useEffect(() => {
     if (processed.current) return;
@@ -35,10 +36,17 @@ export default function AuthCallback() {
         queryClient.invalidateQueries({ queryKey: ['me'] });
         updateUser(user);
 
-        // If we're in a popup/tab opened by window.open (e.g. Google Drive linking during onboarding),
-        // close this window — the opener's polling will detect closure and refresh the user.
-        if (window.opener && !window.opener.closed) {
+        // source=linking means this tab/popup was opened from the onboarding integrations step.
+        // Broadcast the result to the parent tab, then close. If window.close() is blocked
+        // (e.g. Android CCT), render a success screen instead of navigating to /onboarding.
+        const source = searchParams.get('source');
+        if (source === 'linking') {
+          const channel = new BroadcastChannel('continuum_oauth');
+          channel.postMessage({ type: 'GOOGLE_OAUTH_SUCCESS', googleId: user.googleId });
+          channel.close();
           window.close();
+          // If still here, window.close() was blocked — show connected UI instead of navigating
+          setShowConnected(true);
           return;
         }
 
@@ -64,6 +72,20 @@ export default function AuthCallback() {
         navigate('/login?error=oauth_failed');
       });
   }, []);
+
+  if (showConnected) {
+    return (
+      <div className="min-h-screen flex items-center justify-center" style={{ background: '#F8F9FA' }}>
+        <div className="flex flex-col items-center gap-4">
+          <div className="w-12 h-12 rounded-xl flex items-center justify-center" style={{ background: 'rgba(5,150,105,0.10)' }}>
+            <span style={{ fontSize: 24 }}>✓</span>
+          </div>
+          <p className="text-sm font-semibold" style={{ color: '#059669' }}>Google connected!</p>
+          <p className="text-xs" style={{ color: '#6B7280' }}>You can close this tab.</p>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="min-h-screen flex items-center justify-center" style={{ background: '#F8F9FA' }}>

--- a/web/src/pages/onboarding/OnboardingPage.jsx
+++ b/web/src/pages/onboarding/OnboardingPage.jsx
@@ -166,7 +166,7 @@ export default function OnboardingPage() {
     navigate('/dashboard', { replace: true });
   };
 
-  const handleActivationGo = (route) => {
+  const handleActivationGo = async (route) => {
     const goal = user?.onboardingGoal ?? 'not_sure';
     const act = GOAL_ACTIVATION[goal] ?? GOAL_ACTIVATION.not_sure;
     try {
@@ -184,7 +184,8 @@ export default function OnboardingPage() {
       setForceOnboardingOpen(true);
       navigate('/dashboard');
     } else {
-      completeTour();
+      // Must await so tourCompleted is true in React state before AppLayout's guard runs
+      await completeTour();
       navigate(route);
     }
   };


### PR DESCRIPTION
## Summary

- **Onboarding bypass (web):** Logged-in users could navigate directly to `/dashboard` or any app route and skip onboarding entirely — `AppLayout` now redirects to `/onboarding` when `onboardingCompleted` or `tourCompleted` is false. Demo and seed accounts are exempt.
- **Onboarding bypass (Android):** Same gap existed on Android — an authenticated user landed on Dashboard without completing onboarding. `NavProfileUiState` now carries `onboardingCompleted`, `tourCompleted`, and `isLoaded`; a `LaunchedEffect` in `AppNavHost` redirects to the onboarding graph when the profile loads and onboarding is incomplete.
- **Google OAuth tab (web):** Clicking "Connect" on the Integrations step opened a popup/tab that navigated back to `/onboarding` instead of closing. Root cause: `window.opener` is nulled out by browsers during cross-origin OAuth redirects through Google's servers. Fixed by threading `?source=linking` through the OAuth flow via a short-lived `httpOnly` cookie. `AuthCallback` now detects the linking flow, broadcasts `GOOGLE_OAUTH_SUCCESS` via `BroadcastChannel`, calls `window.close()`, and shows a "Google connected! You can close this tab." fallback if the window can't be closed.
- **Google OAuth CCT (Android):** The Chrome Custom Tab had a 1-second one-shot poll that fired before OAuth could finish. Replaced with a `LifecycleEventEffect(ON_RESUME)` that polls the profile when the app returns to foreground after the CCT closes.

## Files changed

| File | Change |
|------|--------|
| `web/src/components/layout/AppLayout.jsx` | Onboarding redirect guard |
| `android/.../NavProfileViewModel.kt` | Add `onboardingCompleted`, `tourCompleted`, `isLoaded` to state |
| `android/.../AppNavHost.kt` | `LaunchedEffect` redirect to onboarding graph |
| `backend/routes/auth.routes.js` | Set `oauth_source` cookie on `?source=linking` |
| `backend/controllers/auth.controller.js` | Read cookie, append `&source=linking` to callback redirect |
| `web/src/pages/auth/AuthCallback.jsx` | `source=linking` check, `BroadcastChannel` broadcast, `window.close()`, fallback UI |
| `web/src/components/onboarding/steps/IntegrationsStep.jsx` | `?source=linking` URL, `BroadcastChannel` listener |
| `android/.../onboarding/steps/IntegrationsStep.kt` | `?source=linking` URL, `ON_RESUME` lifecycle poll |

## Test plan

- [ ] Register a new web account → manually navigate to `/dashboard` → should redirect back to `/onboarding`
- [ ] Complete web onboarding → `/dashboard` is accessible
- [ ] Sign up on Android → force-kill app → reopen → should land on onboarding, not dashboard
- [ ] Web onboarding Integrations step → click Connect → complete Google OAuth → original tab shows ✓ Connected, popup/tab closes (or shows "Google connected!" fallback)
- [ ] Android onboarding Integrations step → tap Connect → CCT shows "Google connected!" → close CCT → Drive card shows ✓ Connected
- [ ] 58 backend auth/onboarding tests pass (`npm test`)
- [ ] Web build succeeds (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)