### PR TITLE
docs: clarify org.gradle.java.home belongs in user-level gradle.properties

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -21,6 +21,5 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
-# org.gradle.java.home is intentionally omitted here.
-# Android Studio sets it automatically when running from the IDE.
-# On CI, actions/setup-java configures the JVM via JAVA_HOME.
+# Machine-specific JDK config (org.gradle.java.home) belongs in
+# ~/.gradle/gradle.properties, not here — CI and teammates have different paths.


### PR DESCRIPTION
## Summary
- Removes the machine-specific `org.gradle.java.home` comment from the project `gradle.properties` and replaces it with a note pointing to the correct location (`~/.gradle/gradle.properties`)
- Prevents CI and teammates from accidentally committing a hardcoded macOS JDK path that would break their builds

## Context
The project `gradle.properties` previously had a comment saying the JDK property was "intentionally omitted" with the wrong reasoning. The fix documents that machine-specific JDK config belongs in the user-level `~/.gradle/gradle.properties` so each machine can point to its own JDK without affecting the repo.

## Test plan
- [ ] Android build succeeds from Android Studio
- [ ] Android build succeeds from terminal (`./gradlew assembleDebug`)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)