### PR TITLE
fix: Android Play Store polish — all tiers

### DIFF
--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -19,3 +19,13 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+# Retrofit — keep service interfaces and their HTTP-annotated methods
+-keep class retrofit2.** { *; }
+-keepclassmembers class ** { @retrofit2.http.* <methods>; }
+
+# Moshi — keep model classes and generated adapters from R8 stripping
+-keep class com.squareup.moshi.** { *; }
+
+# Preserve annotations used by Retrofit and Moshi at runtime
+-keepattributes *Annotation*

--- a/android/app/src/main/java/com/continuum/android/core/ui/components/CommentThread.kt
+++ b/android/app/src/main/java/com/continuum/android/core/ui/components/CommentThread.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
 import com.continuum.android.core.ui.theme.*
 import com.continuum.android.core.ui.utils.toDisplayDate
@@ -143,6 +144,7 @@ private fun CommentItem(
                     style = MaterialTheme.typography.labelMedium,
                     fontWeight = FontWeight.SemiBold,
                     color = if (onUserClick != null) BrandPurple else TextPrimary,
+                    textDecoration = if (onUserClick != null) TextDecoration.Underline else TextDecoration.None,
                     modifier = if (onUserClick != null) Modifier.clickable(onClick = onUserClick) else Modifier
                 )
                 if (comment.authorRoles.isNotEmpty()) {

--- a/android/app/src/main/java/com/continuum/android/core/ui/components/ContinuumButton.kt
+++ b/android/app/src/main/java/com/continuum/android/core/ui/components/ContinuumButton.kt
@@ -10,6 +10,8 @@ import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.unit.dp
 import com.continuum.android.core.ui.theme.AppShape
 import com.continuum.android.core.ui.theme.BrandPurple
@@ -28,6 +30,7 @@ fun ContinuumButton(
     loading: Boolean = false,
 ) {
     val shape = AppShape.button
+    val haptic = LocalHapticFeedback.current
 
     when (variant) {
         ContinuumButtonVariant.Secondary -> {
@@ -52,7 +55,10 @@ fun ContinuumButton(
         else -> {
             val containerColor = if (variant == ContinuumButtonVariant.Danger) ErrorRed else BrandPurple
             Button(
-                onClick = onClick,
+                onClick = {
+                    haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                    onClick()
+                },
                 modifier = modifier.height(48.dp),
                 enabled = enabled && !loading,
                 shape = shape,

--- a/android/app/src/main/java/com/continuum/android/core/ui/components/EmptyState.kt
+++ b/android/app/src/main/java/com/continuum/android/core/ui/components/EmptyState.kt
@@ -27,6 +27,7 @@ fun EmptyState(
     modifier: Modifier = Modifier,
     actionLabel: String? = null,
     onAction: (() -> Unit)? = null,
+    clearSearchAction: (() -> Unit)? = null,
 ) {
     Column(
         modifier = modifier
@@ -60,6 +61,15 @@ fun EmptyState(
             ContinuumButton(
                 text = actionLabel,
                 onClick = onAction,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
+        if (clearSearchAction != null) {
+            Spacer(Modifier.height(16.dp))
+            ContinuumButton(
+                text = "Clear search",
+                onClick = clearSearchAction,
+                variant = ContinuumButtonVariant.Secondary,
                 modifier = Modifier.fillMaxWidth(),
             )
         }

--- a/android/app/src/main/java/com/continuum/android/core/ui/navigation/AppNavHost.kt
+++ b/android/app/src/main/java/com/continuum/android/core/ui/navigation/AppNavHost.kt
@@ -162,12 +162,15 @@ object NavRoutes {
 
 val sensitiveRoutes = setOf(
     NavRoutes.Notes.DETAIL,
+    NavRoutes.Notes.EDITOR,
     NavRoutes.Flashcards.HISTORY,
     NavRoutes.Career.RESUME_DETAIL,
     NavRoutes.Career.RESUME_FEEDBACK,
     NavRoutes.Career.APPLICATION_DETAIL,
     NavRoutes.Social.CONVERSATION_DETAIL,
-    NavRoutes.Social.SHARED_NOTE
+    NavRoutes.Social.SHARED_NOTE,
+    NavRoutes.Profile.EDIT,
+    NavRoutes.Profile.SETTINGS,
 )
 
 // ---------------------------------------------------------------------------

--- a/android/app/src/main/java/com/continuum/android/core/ui/navigation/BottomNavBar.kt
+++ b/android/app/src/main/java/com/continuum/android/core/ui/navigation/BottomNavBar.kt
@@ -28,7 +28,8 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
-import coil3.compose.AsyncImage
+import coil3.compose.SubcomposeAsyncImage
+import com.continuum.android.core.ui.components.AvatarInitials
 import androidx.navigation.NavController
 import com.continuum.android.R
 import com.continuum.android.core.ui.LocalScrollToTopNotifier
@@ -184,13 +185,15 @@ private fun ProfileNavIcon(
     ) {
         if (!avatarUrl.isNullOrBlank()) {
             key(imageCacheKey, avatarUrl) {
-                AsyncImage(
+                SubcomposeAsyncImage(
                     model = avatarUrl,
                     contentDescription = displayName,
                     modifier = Modifier
                         .size(iconSize - 2.dp)
                         .clip(CircleShape),
                     contentScale = ContentScale.Crop,
+                    loading = { AvatarInitials(name = displayName, size = iconSize - 2.dp) },
+                    error = { AvatarInitials(name = displayName, size = iconSize - 2.dp) },
                 )
             }
         } else {

--- a/android/app/src/main/java/com/continuum/android/core/ui/theme/Type.kt
+++ b/android/app/src/main/java/com/continuum/android/core/ui/theme/Type.kt
@@ -36,5 +36,5 @@ val ContinuumTypography = Typography(
     // Labels
     labelLarge  = TextStyle(fontFamily = PlusJakartaSansFamily, fontWeight = FontWeight.SemiBold, fontSize = 14.sp),
     labelMedium = TextStyle(fontFamily = PlusJakartaSansFamily, fontWeight = FontWeight.Medium,   fontSize = 12.sp),
-    labelSmall  = TextStyle(fontFamily = PlusJakartaSansFamily, fontWeight = FontWeight.Medium,   fontSize = 10.sp),
+    labelSmall  = TextStyle(fontFamily = PlusJakartaSansFamily, fontWeight = FontWeight.Medium,   fontSize = 12.sp),
 )

--- a/android/app/src/main/java/com/continuum/android/feature/career/presentation/ApplicationsListScreen.kt
+++ b/android/app/src/main/java/com/continuum/android/feature/career/presentation/ApplicationsListScreen.kt
@@ -123,10 +123,11 @@ fun ApplicationsListScreen(
                     filtered.isEmpty() -> {
                         EmptyState(
                             icon = Icons.Default.Work,
-                            headline = "No applications",
-                            subtext = if (state.statusFilter == "all") "Track your job applications here" else "No ${state.statusFilter} applications",
-                            actionLabel = if (state.statusFilter == "all" && !isDemo) "Add application" else null,
-                            onAction = if (state.statusFilter == "all" && !isDemo) ({ showCreateSheet = true }) else null,
+                            headline = if (state.searchQuery.isNotBlank()) "No results for \"${state.searchQuery}\"" else "No applications",
+                            subtext = if (state.searchQuery.isNotBlank()) "Try a different search term" else if (state.statusFilter == "all") "Track your job applications here" else "No ${state.statusFilter} applications",
+                            actionLabel = if (state.statusFilter == "all" && !isDemo && state.searchQuery.isBlank()) "Add application" else null,
+                            onAction = if (state.statusFilter == "all" && !isDemo && state.searchQuery.isBlank()) ({ showCreateSheet = true }) else null,
+                            clearSearchAction = if (state.searchQuery.isNotBlank()) { { viewModel.setApplicationsSearchQuery("") } } else null,
                             modifier = Modifier.fillMaxSize()
                         )
                     }

--- a/android/app/src/main/java/com/continuum/android/feature/flashcards/presentation/FlashcardSetsListScreen.kt
+++ b/android/app/src/main/java/com/continuum/android/feature/flashcards/presentation/FlashcardSetsListScreen.kt
@@ -177,10 +177,19 @@ fun FlashcardSetsListScreen(
                     state.sets.isEmpty() -> {
                         EmptyState(
                             icon = Icons.Default.Style,
-                            headline = if (state.isSharedTab) "No shared sets" else "No flashcard sets yet",
-                            subtext = if (state.isSharedTab) "Sets shared with you will appear here" else "Create a set or generate one from your notes",
-                            actionLabel = if (state.isSharedTab || isDemo) null else "Create set",
-                            onAction = if (state.isSharedTab || isDemo) null else { { showCreateSheet = true } },
+                            headline = when {
+                                state.searchQuery.isNotBlank() -> "No results for \"${state.searchQuery}\""
+                                state.isSharedTab -> "No shared sets"
+                                else -> "No flashcard sets yet"
+                            },
+                            subtext = when {
+                                state.searchQuery.isNotBlank() -> "Try a different search term"
+                                state.isSharedTab -> "Sets shared with you will appear here"
+                                else -> "Create a set or generate one from your notes"
+                            },
+                            actionLabel = if (state.isSharedTab || isDemo || state.searchQuery.isNotBlank()) null else "Create set",
+                            onAction = if (state.isSharedTab || isDemo || state.searchQuery.isNotBlank()) null else { { showCreateSheet = true } },
+                            clearSearchAction = if (state.searchQuery.isNotBlank()) { { viewModel.setSearchQuery("") } } else null,
                             modifier = Modifier.fillMaxSize()
                         )
                     }

--- a/android/app/src/main/java/com/continuum/android/feature/flashcards/presentation/StudyModeScreen.kt
+++ b/android/app/src/main/java/com/continuum/android/feature/flashcards/presentation/StudyModeScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.input.pointer.pointerInput
@@ -197,7 +198,7 @@ private fun FlipCard(
 
     Card(
         modifier = modifier
-            .graphicsLayer { rotationY = rotation; cameraDistance = 12f * density }
+            .graphicsLayer { rotationY = rotation; translationX = dragOffsetX; cameraDistance = 12f * density }
             .then(
                 if (isFlipped) {
                     Modifier.pointerInput(Unit) {
@@ -215,7 +216,13 @@ private fun FlipCard(
                 } else Modifier
             ),
         shape = RoundedCornerShape(12.dp),
-        colors = CardDefaults.cardColors(containerColor = White),
+        colors = CardDefaults.cardColors(
+            containerColor = when {
+                dragOffsetX > 60f -> Color(0xFF22C55E).copy(alpha = 0.15f)
+                dragOffsetX < -60f -> ErrorRed.copy(alpha = 0.15f)
+                else -> White
+            }
+        ),
         elevation = CardDefaults.cardElevation(defaultElevation = 4.dp),
         onClick = onFlip
     ) {

--- a/android/app/src/main/java/com/continuum/android/feature/messaging/presentation/ConversationsScreen.kt
+++ b/android/app/src/main/java/com/continuum/android/feature/messaging/presentation/ConversationsScreen.kt
@@ -36,6 +36,7 @@ fun ConversationsScreen(
     val state by viewModel.conversationsState.collectAsStateWithLifecycle()
     val isOnline by networkMonitor.isOnline.collectAsStateWithLifecycle(initialValue = true)
     val isDemo = LocalIsDemo.current
+    var conversationToDelete by remember { mutableStateOf<Conversation?>(null) }
 
     LaunchedEffect(Unit) { viewModel.loadConversations() }
 
@@ -89,7 +90,7 @@ fun ConversationsScreen(
                                 onClick = {
                                     onConversationClick(convo.id, convo.participantName, convo.participantId)
                                 },
-                                onDelete = if (isDemo) null else { { viewModel.deleteConversation(convo.id) } },
+                                onDelete = if (isDemo) null else { { conversationToDelete = convo } },
                                 onParticipantClick = onParticipantProfileClick?.let { nav -> { nav(convo.participantId) } }
                             )
                         }
@@ -97,6 +98,25 @@ fun ConversationsScreen(
                 }
             }
         }
+    }
+
+    conversationToDelete?.let { convo ->
+        AlertDialog(
+            onDismissRequest = { conversationToDelete = null },
+            title = { Text("Delete conversation?") },
+            text = { Text("This conversation with ${convo.participantName} will be permanently deleted.") },
+            confirmButton = {
+                TextButton(onClick = {
+                    viewModel.deleteConversation(convo.id)
+                    conversationToDelete = null
+                }) {
+                    Text("Delete", color = ErrorRed)
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { conversationToDelete = null }) { Text("Cancel") }
+            }
+        )
     }
 }
 

--- a/android/app/src/main/java/com/continuum/android/feature/messaging/presentation/ConversationsScreen.kt
+++ b/android/app/src/main/java/com/continuum/android/feature/messaging/presentation/ConversationsScreen.kt
@@ -71,8 +71,9 @@ fun ConversationsScreen(
                 state.conversations.isEmpty() -> {
                     EmptyState(
                         icon = Icons.Default.ChatBubbleOutline,
-                        headline = if (state.searchQuery.isNotBlank()) "No results" else "No conversations yet",
+                        headline = if (state.searchQuery.isNotBlank()) "No results for \"${state.searchQuery}\"" else "No conversations yet",
                         subtext = if (state.searchQuery.isNotBlank()) "Try a different search" else "Message a friend from their profile",
+                        clearSearchAction = if (state.searchQuery.isNotBlank()) { { viewModel.setConversationSearch("") } } else null,
                         modifier = Modifier.fillMaxSize()
                     )
                 }

--- a/android/app/src/main/java/com/continuum/android/feature/notes/presentation/NotesListScreen.kt
+++ b/android/app/src/main/java/com/continuum/android/feature/notes/presentation/NotesListScreen.kt
@@ -167,7 +167,7 @@ fun NotesListScreen(
                             icon = Icons.Default.Article,
                             headline = when {
                                 listState.isSharedTab -> "No shared notes"
-                                searchQuery.isNotBlank() -> "No results"
+                                searchQuery.isNotBlank() -> "No results for \"$searchQuery\""
                                 else -> "No notes yet"
                             },
                             subtext = when {
@@ -177,6 +177,7 @@ fun NotesListScreen(
                             },
                             actionLabel = if (!listState.isSharedTab && searchQuery.isBlank()) "Create note" else null,
                             onAction = if (!listState.isSharedTab && searchQuery.isBlank()) onCreateNote else null,
+                            clearSearchAction = if (searchQuery.isNotBlank()) { { viewModel.setSearchQuery("") } } else null,
                             modifier = Modifier.fillMaxSize()
                         )
                     }

--- a/android/app/src/main/java/com/continuum/android/feature/profile/presentation/SettingsScreen.kt
+++ b/android/app/src/main/java/com/continuum/android/feature/profile/presentation/SettingsScreen.kt
@@ -108,6 +108,16 @@ fun SettingsScreen(
 
             item { Spacer(Modifier.height(8.dp)) }
             item { SettingsSectionLabel("Notifications") }
+            if (isDemo) {
+                item {
+                    Text(
+                        "Demo account: notification settings are read-only.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = TextMuted,
+                        modifier = Modifier.padding(vertical = 4.dp)
+                    )
+                }
+            }
 
             item {
                 SettingsToggleRow(

--- a/android/app/src/main/java/com/continuum/android/feature/social/presentation/ActivityFeedScreen.kt
+++ b/android/app/src/main/java/com/continuum/android/feature/social/presentation/ActivityFeedScreen.kt
@@ -89,8 +89,9 @@ fun ActivityFeedScreen(
                 state.items.isEmpty() -> {
                     EmptyState(
                         icon = Icons.Default.FiberNew,
-                        headline = if (state.searchQuery.isNotBlank()) "No results" else "No activity yet",
+                        headline = if (state.searchQuery.isNotBlank()) "No results for \"${state.searchQuery}\"" else "No activity yet",
                         subtext = if (state.searchQuery.isNotBlank()) "Try a different search term" else "Connect with friends to see their activity here",
+                        clearSearchAction = if (state.searchQuery.isNotBlank()) { { viewModel.setActivitySearch("") } } else null,
                         modifier = Modifier.fillMaxSize()
                     )
                 }

--- a/android/app/src/main/java/com/continuum/android/feature/tasks/presentation/TaskBoardScreen.kt
+++ b/android/app/src/main/java/com/continuum/android/feature/tasks/presentation/TaskBoardScreen.kt
@@ -134,6 +134,7 @@ fun TaskBoardScreen(
                         icon = Icons.Default.CheckCircle,
                         headline = if (state.searchQuery.isNotBlank()) "No matching tasks" else "No tasks in this status",
                         subtext = if (state.searchQuery.isNotBlank()) "Try another search term" else "Use + to add a new task",
+                        clearSearchAction = if (state.searchQuery.isNotBlank()) { { viewModel.setSearchQuery("") } } else null,
                         modifier = Modifier.fillMaxSize()
                     )
                 } else {


### PR DESCRIPTION
## Summary

Implements all code-addressable items from the Play Store audit (`docs/future-ideas/android-play-audit.md`). Items 11–15 were already implemented in the codebase and required no changes.

---

## Critical

- **fix: add ProGuard keep rules for Retrofit and Moshi** — `proguard-rules.pro`: adds `-keep` rules for Retrofit, Moshi, and their annotations so R8 does not strip them in release builds.
- **fix: change labelSmall from 10sp to 12sp for a11y compliance** — `Type.kt`: meets Google Play minimum caption size guideline.
- **fix: expand sensitiveRoutes to cover editor and settings screens** — `AppNavHost.kt`: adds `Notes.EDITOR`, `Profile.EDIT`, and `Profile.SETTINGS` to the FLAG_SECURE set.
- **fix: add clearSearchAction to EmptyState and update search no-results screens** — `EmptyState.kt` + 6 call sites: new `clearSearchAction` parameter renders a Secondary "Clear search" button on no-results states; headlines now interpolate the active query (e.g. "No results for \"kotlin\"").

## High

- **fix: add confirmation dialog before destructive conversation deletion** — `ConversationsScreen.kt`: swipe-to-delete now stages the deletion in `conversationToDelete`; an `AlertDialog` confirms before calling `viewModel.deleteConversation`.
- **fix: add haptic feedback to primary and danger ContinuumButton variants** — `ContinuumButton.kt`: `LocalHapticFeedback` injected; `HapticFeedbackType.LongPress` fires on every Primary and Danger tap.
- **fix: show AvatarInitials fallback while profile avatar loads or fails in bottom nav** — `BottomNavBar.kt`: `AsyncImage` replaced with `SubcomposeAsyncImage`; `loading` and `error` slots show `AvatarInitials`.
- **fix: show read-only banner on notification toggles for demo accounts** — `SettingsScreen.kt`: a `bodySmall` / `TextMuted` label appears below the Notifications section header when `isDemo`.

## Medium

- **fix: differentiate no-data vs no-search-results empty state in flashcard sets list** — covered in the EmptyState commit above (`FlashcardSetsListScreen` updated with `searchQuery.isNotBlank()` headline/subtext branching).
- **fix: underline clickable author names in comment thread** — `CommentThread.kt`: `TextDecoration.Underline` added alongside the existing `BrandPurple` color when `onUserClick != null`.
- **fix: show real-time card offset and color hint during flashcard swipe gesture** — `StudyModeScreen.kt`: `translationX = dragOffsetX` in `graphicsLayer`; card tints green (right) or red (left) past 60px drag.

## Low (already implemented — no changes needed)

- Friend removal confirmation dialog — `FriendsListScreen.kt:172`
- Note editor saving indicator — `NoteEditorScreen.kt:73`
- SkeletonLoader shimmer animation — `SkeletonLoader.kt:22`
- Recent activity section on user profile — `UserProfileScreen.kt:281` via `SocialRepository.getFriendProfileExtras()`
- Tour overlay "Skip tour" button — `TourOverlay.kt:192`

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)