### PR TITLE
fix: detect phones and tablets by device type, not screen width

### DIFF
--- a/web/e2e/mobile.spec.ts
+++ b/web/e2e/mobile.spec.ts
@@ -1,62 +1,38 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, devices } from '@playwright/test';
 
-// Viewports used throughout
-const MOBILE = { width: 390, height: 844 };   // iPhone 14 — below 1024px breakpoint
-const TABLET = { width: 1024, height: 768 };  // exactly at breakpoint — should see desktop
-const DESKTOP = { width: 1280, height: 800 }; // well above breakpoint
+const DESKTOP = { width: 1280, height: 800 };
 
-// ─── Mobile gate renders below 1024px ────────────────────────────────────────
+// ─── Mobile gate (phone UA) ───────────────────────────────────────────────────
 
 test.describe('Mobile gate', () => {
+  test.use({ ...devices['iPhone 14'] });
+
   test('shows mobile gate (not app) at mobile viewport', async ({ page }) => {
-    await page.setViewportSize(MOBILE);
     await page.goto('/');
-    // Hero headline is unique to MobileGate
     await expect(page.locator('h1')).toContainText('Stop switching between 8 apps');
-    // App navigation (sidebar/dashboard) must NOT be present
     await expect(page.locator('text=Dashboard')).not.toBeVisible();
   });
 
-  test('shows landing page (not mobile gate) at desktop viewport', async ({ page }) => {
-    await page.setViewportSize(DESKTOP);
-    await page.goto('/');
-    // Landing page has different hero and nav links
-    await expect(page.locator('text=Stop switching between 8 apps')).toBeVisible();
-    await expect(page.locator('h1')).not.toContainText('Your student workspace');
-  });
-
-  test('shows landing page at exactly 1024px (breakpoint is strictly less-than)', async ({ page }) => {
-    await page.setViewportSize(TABLET);
-    await page.goto('/');
-    await expect(page.locator('text=Stop switching between 8 apps')).toBeVisible();
-  });
-
   test('nav bar renders with logo and join-waitlist link', async ({ page }) => {
-    await page.setViewportSize(MOBILE);
     await page.goto('/');
     await expect(page.locator('nav img[alt="Continuum"]')).toBeVisible();
     await expect(page.locator('nav button:has-text("Join the waitlist")')).toBeVisible();
   });
 
   test('nav "Join the waitlist" scrolls to the form section', async ({ page }) => {
-    await page.setViewportSize(MOBILE);
     await page.goto('/');
     await page.click('nav button:has-text("Join the waitlist")');
-    // After scroll, the form section heading should be in view
     await expect(page.locator('#waitlist-form')).toBeInViewport({ timeout: 2000 });
   });
 
   test('hero CTA scrolls to form', async ({ page }) => {
-    await page.setViewportSize(MOBILE);
     await page.goto('/');
-    // The hero "Join the waitlist" button is inside the hero section (not nav)
     const heroCTA = page.locator('section').first().locator('button:has-text("Join the waitlist")');
     await heroCTA.click();
     await expect(page.locator('#waitlist-form')).toBeInViewport({ timeout: 2000 });
   });
 
   test('renders all 6 feature items', async ({ page }) => {
-    await page.setViewportSize(MOBILE);
     await page.goto('/');
     for (const label of ['Notes & AI summaries', 'Tasks & deadlines', 'Smart flashcards', 'Career pipeline', 'Social & collaboration', 'Tool integrations']) {
       await expect(page.locator(`text=${label}`)).toBeVisible();
@@ -64,29 +40,43 @@ test.describe('Mobile gate', () => {
   });
 });
 
+// ─── Desktop UA — gate does not show ─────────────────────────────────────────
+
+test.describe('Mobile gate (desktop UA)', () => {
+  test('shows landing page (not mobile gate) at desktop viewport', async ({ page }) => {
+    await page.setViewportSize(DESKTOP);
+    await page.goto('/');
+    await expect(page.locator('text=Stop switching between 8 apps')).toBeVisible();
+    await expect(page.locator('h1')).not.toContainText('Your student workspace');
+  });
+
+  test('shows landing page on desktop UA regardless of viewport width', async ({ page }) => {
+    await page.setViewportSize({ width: 1024, height: 768 });
+    await page.goto('/');
+    await expect(page.locator('text=Stop switching between 8 apps')).toBeVisible();
+  });
+});
+
 // ─── Waitlist form ────────────────────────────────────────────────────────────
 
 test.describe('Mobile waitlist form', () => {
+  test.use({ ...devices['iPhone 14'] });
+
   test.beforeEach(async ({ page }) => {
-    await page.setViewportSize(MOBILE);
     await page.goto('/');
     await page.click('nav button:has-text("Join the waitlist")');
   });
 
   test('submit button is disabled until all three fields are filled', async ({ page }) => {
     const submit = page.locator('#waitlist-form button[type="submit"]');
-    // Initially disabled
     await expect(submit).toBeDisabled();
 
-    // Fill firstName only
     await page.fill('#waitlist-form input[type="text"]', 'Alex');
     await expect(submit).toBeDisabled();
 
-    // Fill email only (no platform selected yet)
     await page.fill('#waitlist-form input[type="email"]', 'alex@example.com');
     await expect(submit).toBeDisabled();
 
-    // Select platform — now all three are set
     await page.click('#waitlist-form button:has-text("iOS")');
     await expect(submit).not.toBeDisabled();
   });
@@ -94,7 +84,6 @@ test.describe('Mobile waitlist form', () => {
   test('platform pills are mutually exclusive', async ({ page }) => {
     await page.click('#waitlist-form button:has-text("Android")');
     await page.click('#waitlist-form button:has-text("Both")');
-    // "Both" is selected, Android is not
     const androidBtn = page.locator('#waitlist-form button:has-text("Android")');
     const bothBtn = page.locator('#waitlist-form button:has-text("Both")');
     await expect(bothBtn).toHaveCSS('background-color', 'rgb(107, 33, 168)');
@@ -121,14 +110,12 @@ test.describe('Mobile waitlist form', () => {
   test('duplicate email shows 409 error', async ({ page }) => {
     const email = `dup-gate-${Date.now()}@example.com`;
 
-    // First submission
     await page.click('#waitlist-form button:has-text("iOS")');
     await page.fill('#waitlist-form input[type="text"]', 'Test');
     await page.fill('#waitlist-form input[type="email"]', email);
     await page.click('#waitlist-form button[type="submit"]');
     await expect(page.locator("text=You're on the list.")).toBeVisible({ timeout: 8000 });
 
-    // Reload and try again with same email
     await page.reload();
     await page.click('nav button:has-text("Join the waitlist")');
     await page.click('#waitlist-form button:has-text("iOS")');
@@ -142,48 +129,47 @@ test.describe('Mobile waitlist form', () => {
 // ─── Legal pages accessible on mobile ────────────────────────────────────────
 
 test.describe('Mobile legal pages', () => {
+  test.use({ ...devices['iPhone 14'] });
+
   test('/privacy is accessible at mobile viewport and shows policy content', async ({ page }) => {
-    await page.setViewportSize(MOBILE);
     await page.goto('/privacy');
     await expect(page.locator('h1')).toContainText('Privacy Policy');
     await expect(page.locator('h2:has-text("Information We Collect")')).toBeVisible();
-    // Full app must NOT render
     await expect(page.locator('text=Dashboard')).not.toBeVisible();
   });
 
   test('/terms is accessible at mobile viewport and shows terms content', async ({ page }) => {
-    await page.setViewportSize(MOBILE);
     await page.goto('/terms');
     await expect(page.locator('h1')).toContainText('Terms of Service');
     await expect(page.locator('h2:has-text("Acceptance of Terms")')).toBeVisible();
   });
 
   test('/privacy nav has logo and "Join the waitlist" link', async ({ page }) => {
-    await page.setViewportSize(MOBILE);
     await page.goto('/privacy');
     await expect(page.locator('nav img[alt="Continuum"]')).toBeVisible();
     await expect(page.locator('nav a:has-text("Join the waitlist")')).toBeVisible();
   });
 
   test('"Join the waitlist" on /privacy navigates to gate and scrolls to form', async ({ page }) => {
-    await page.setViewportSize(MOBILE);
     await page.goto('/privacy');
     await page.click('nav a:has-text("Join the waitlist")');
     await expect(page).toHaveURL('/');
     await expect(page.locator('#waitlist-form')).toBeInViewport({ timeout: 3000 });
   });
 
-  test('/privacy and /terms show desktop versions at desktop viewport', async ({ page }) => {
-    await page.setViewportSize(DESKTOP);
-    await page.goto('/privacy');
-    // Desktop PrivacyPolicy uses MarketingNav, not the mobile sticky nav
-    await expect(page.locator('nav img[alt="Continuum"]')).not.toBeVisible();
-  });
-
   test('table of contents anchor links work on /privacy', async ({ page }) => {
-    await page.setViewportSize(MOBILE);
     await page.goto('/privacy');
     await page.click('a:has-text("Google Drive Data")');
     await expect(page.locator('#google-drive')).toBeInViewport({ timeout: 2000 });
+  });
+});
+
+// ─── Legal pages (desktop UA) ─────────────────────────────────────────────────
+
+test.describe('Legal pages (desktop UA)', () => {
+  test('/privacy and /terms show desktop versions at desktop viewport', async ({ page }) => {
+    await page.setViewportSize(DESKTOP);
+    await page.goto('/privacy');
+    await expect(page.locator('nav img[alt="Continuum"]')).not.toBeVisible();
   });
 });

--- a/web/e2e/mobile.spec.ts
+++ b/web/e2e/mobile.spec.ts
@@ -2,10 +2,13 @@ import { test, expect, devices } from '@playwright/test';
 
 const DESKTOP = { width: 1280, height: 800 };
 
+// Strip defaultBrowserType so test.use() works inside describe blocks
+const { defaultBrowserType: _bt, ...IPHONE_14 } = devices['iPhone 14'];
+
 // ─── Mobile gate (phone UA) ───────────────────────────────────────────────────
 
 test.describe('Mobile gate', () => {
-  test.use({ ...devices['iPhone 14'] });
+  test.use(IPHONE_14);
 
   test('shows mobile gate (not app) at mobile viewport', async ({ page }) => {
     await page.goto('/');
@@ -60,7 +63,7 @@ test.describe('Mobile gate (desktop UA)', () => {
 // ─── Waitlist form ────────────────────────────────────────────────────────────
 
 test.describe('Mobile waitlist form', () => {
-  test.use({ ...devices['iPhone 14'] });
+  test.use(IPHONE_14);
 
   test.beforeEach(async ({ page }) => {
     await page.goto('/');
@@ -129,7 +132,7 @@ test.describe('Mobile waitlist form', () => {
 // ─── Legal pages accessible on mobile ────────────────────────────────────────
 
 test.describe('Mobile legal pages', () => {
-  test.use({ ...devices['iPhone 14'] });
+  test.use(IPHONE_14);
 
   test('/privacy is accessible at mobile viewport and shows policy content', async ({ page }) => {
     await page.goto('/privacy');

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -33,6 +33,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "dompurify": "^3.4.1",
+        "is-mobile": "^5.0.0",
         "lucide-react": "^0.468.0",
         "marked": "^17.0.5",
         "posthog-js": "^1.369.5",
@@ -5183,6 +5184,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/is-mobile": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-mobile/-/is-mobile-5.0.0.tgz",
+      "integrity": "sha512-Tz/yndySvLAEXh+Uk8liFCxOwVH6YutuR74utvOcu7I9Di+DwM0mtdPVZNaVvvBUM2OXxne/NhOs1zAO7riusQ==",
+      "license": "MIT"
     },
     "node_modules/is-number": {
       "version": "7.0.0",

--- a/web/package.json
+++ b/web/package.json
@@ -36,6 +36,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "dompurify": "^3.4.1",
+    "is-mobile": "^5.0.0",
     "lucide-react": "^0.468.0",
     "marked": "^17.0.5",
     "posthog-js": "^1.369.5",

--- a/web/src/hooks/useMobile.js
+++ b/web/src/hooks/useMobile.js
@@ -1,20 +1,23 @@
 import { useState, useEffect } from 'react';
+import isMobileLib from 'is-mobile';
 
-const MOBILE_BREAKPOINT = 1024; // covers phones and portrait-orientation tablets (lg: breakpoint)
+function isPhoneOrTablet() {
+  // Modern Chromium browsers (Chrome, Edge, Opera) expose this natively
+  if (navigator.userAgentData?.mobile === true) return true;
+  // Safari, Firefox, and others: UA string parsing + maxTouchPoints for iPads
+  return isMobileLib({ tablet: true });
+}
 
 export function useMobile() {
-  const [isMobile, setIsMobile] = useState(
-    // Note: if SSR is ever added, guard with typeof window !== 'undefined'
-    () => window.innerWidth < MOBILE_BREAKPOINT
-  );
+  const [isMobile, setIsMobile] = useState(() => isPhoneOrTablet());
 
   useEffect(() => {
-    function handleResize() {
-      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
+    // Re-evaluate on orientation change in case layout needs updating
+    function handleOrientationChange() {
+      setIsMobile(isPhoneOrTablet());
     }
-    window.addEventListener('resize', handleResize);
-    handleResize();
-    return () => window.removeEventListener('resize', handleResize);
+    window.addEventListener('orientationchange', handleOrientationChange);
+    return () => window.removeEventListener('orientationchange', handleOrientationChange);
   }, []);
 
   return isMobile;


### PR DESCRIPTION
## Summary
- Replaced `window.innerWidth < 1024` breakpoint logic with true device-type detection
- Added `is-mobile` package for UA string parsing with iPad support (`maxTouchPoints`)
- Checks `navigator.userAgentData.mobile` first (Chrome/Edge/Opera native support), then falls back to `is-mobile` for Safari/Firefox
- Swapped `resize` listener for `orientationchange` — device class never changes on resize
- Phones and tablets (including iPads in landscape) now correctly see the MobileGate

## Why
The old width-only check broke on tablets in landscape mode (e.g. iPad at 1024px+ passed through to the web app, which isn't responsive for non-desktop devices). Device-type detection is the correct long-term signal here.