### PR TITLE
fix: detect iPadOS 13+ via maxTouchPoints when UA reports as Macintosh

### DIFF
--- a/web/src/hooks/useMobile.js
+++ b/web/src/hooks/useMobile.js
@@ -4,7 +4,9 @@ import isMobileLib from 'is-mobile';
 function isPhoneOrTablet() {
   // Modern Chromium browsers (Chrome, Edge, Opera) expose this natively
   if (navigator.userAgentData?.mobile === true) return true;
-  // Safari, Firefox, and others: UA string parsing + maxTouchPoints for iPads
+  // iPadOS 13+ reports UA as Macintosh but has multiple touch points; real Macs have 0
+  if (/Macintosh/i.test(navigator.userAgent) && navigator.maxTouchPoints > 1) return true;
+  // All other phones and tablets via UA string parsing
   return isMobileLib({ tablet: true });
 }
 


### PR DESCRIPTION
## Summary
- iPadOS 13+ changed the default iPad user agent to `Macintosh; Intel Mac OS X`, identical to a desktop Mac, to force websites to serve desktop layouts
- `is-mobile` and UA string parsing alone cannot distinguish an iPad from a MacBook in this case
- Added a `maxTouchPoints > 1` check: real Macs always report `0`, iPads report `10`
- This runs after the `userAgentData.mobile` check (Chromium) and before the `is-mobile` fallback

## Why it was missed
The original implementation relied on `is-mobile({ tablet: true })` to handle iPads, but that library only parses UA strings — it has no knowledge of `maxTouchPoints`.

## Tested on
- iPad (iPadOS 17) — now correctly shows MobileGate