### PR TITLE
feat: detailed PostHog events for activity feed and notifications

### DIFF
--- a/web/src/components/ui/ActivityFeedItem.jsx
+++ b/web/src/components/ui/ActivityFeedItem.jsx
@@ -2,6 +2,7 @@ import { Link, useNavigate } from 'react-router-dom';
 import AppAvatar from '@/components/ui/AppAvatar';
 import VerifiedBadge from '@/components/ui/VerifiedBadge';
 import { formatRelative } from '@/lib/utils';
+import { posthog } from '@/lib/posthog';
 
 function fullName(u) {
   return [u?.firstName, u?.lastName].filter(Boolean).join(' ') || u?.username || 'Someone';
@@ -122,9 +123,19 @@ export default function ActivityFeedItem({ item, isLast = false }) {
   const navigate = useNavigate();
   const rowNav = getRowNav(item);
 
+  function handleRowClick() {
+    if (!rowNav) return;
+    posthog.capture('activity_item_clicked', {
+      type: item.type,
+      target_type: item.targetType,
+      actor_id: actor?._id,
+    });
+    navigate(rowNav.to, { state: rowNav.state });
+  }
+
   return (
     <div
-      onClick={rowNav ? () => navigate(rowNav.to, { state: rowNav.state }) : undefined}
+      onClick={rowNav ? handleRowClick : undefined}
       style={{
         display: 'flex',
         alignItems: 'flex-start',

--- a/web/src/pages/Activity.jsx
+++ b/web/src/pages/Activity.jsx
@@ -1,8 +1,9 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useInfiniteQuery, useQueryClient } from '@tanstack/react-query';
 import { useAuth } from '@/context/AuthContext';
 import { Activity as ActivityIcon, Search } from 'lucide-react';
 import api from '@/lib/api';
+import { posthog } from '@/lib/posthog';
 import Button from '@/components/ui/Button';
 import ActivitySkeleton from '@/components/skeletons/ActivitySkeleton';
 import ActivityFeedItem from '@/components/ui/ActivityFeedItem';
@@ -13,6 +14,8 @@ export default function Activity() {
   const [actSearch, setActSearch] = useState('');
   const { updateUser } = useAuth();
   const queryClient = useQueryClient();
+  const searchDebounceRef = useRef(null);
+  const viewedRef = useRef(false);
 
   useEffect(() => {
     api.put('/activity/mark-seen').then(() => {
@@ -45,6 +48,31 @@ export default function Activity() {
 
   const activities = data?.pages.flatMap(p => p.feed) ?? [];
 
+  // Fire feed_viewed once after first successful load
+  useEffect(() => {
+    if (!isLoading && data && !viewedRef.current) {
+      viewedRef.current = true;
+      posthog.capture('activity_feed_viewed', { total_items: activities.length });
+    }
+  }, [isLoading, data]);
+
+  // Debounced search tracking
+  const handleSearchChange = (e) => {
+    const value = e.target.value;
+    setActSearch(value);
+    if (searchDebounceRef.current) clearTimeout(searchDebounceRef.current);
+    if (value.trim()) {
+      searchDebounceRef.current = setTimeout(() => {
+        posthog.capture('activity_searched', { query: value.trim(), results: activities.length });
+      }, 1000);
+    }
+  };
+
+  function handleLoadMore() {
+    fetchNextPage();
+    posthog.capture('activity_load_more', { loaded_so_far: activities.length });
+  }
+
   return (
     <div>
       <div style={{ marginBottom: 16 }}>
@@ -75,7 +103,7 @@ export default function Activity() {
           }}
           placeholder="Search activity by name or content..."
           value={actSearch}
-          onChange={e => setActSearch(e.target.value)}
+          onChange={handleSearchChange}
         />
       </div>
 
@@ -116,7 +144,7 @@ export default function Activity() {
 
         {hasNextPage && (
           <div style={{ padding: '16px 20px', borderTop: '1px solid #E5E7EB', textAlign: 'center' }}>
-            <Button variant="outline" size="sm" onClick={() => fetchNextPage()} loading={isFetchingNextPage}>
+            <Button variant="outline" size="sm" onClick={handleLoadMore} loading={isFetchingNextPage}>
               Load more
             </Button>
           </div>

--- a/web/src/pages/Notifications.jsx
+++ b/web/src/pages/Notifications.jsx
@@ -99,6 +99,7 @@ export default function Notifications() {
     function handleDelete(notif, e) {
         e.stopPropagation();
         deleteNotif({ id: notif._id, type: notif.type });
+        posthog.capture('notification_dismissed', { type: notif.type, target_type: notif.targetType });
     }
 
     return (


### PR DESCRIPTION
## Summary

- **Activity feed** (`Activity.jsx` + `ActivityFeedItem.jsx`): adds four new PostHog events
  - `activity_feed_viewed` — fires once after first successful load with `{ total_items }`
  - `activity_searched` — fires 1s after the user stops typing with `{ query, results }`
  - `activity_load_more` — fires on "Load more" click with `{ loaded_so_far }`
  - `activity_item_clicked` — fires on row click with `{ type, target_type, actor_id }`
- **Notifications page** (`Notifications.jsx`): adds the missing `notification_dismissed` event (was in the original plan for the bell PR but never wired to `handleDelete`)
  - `notification_dismissed` — fires with `{ type, target_type }` when the X button is clicked

## Test plan

- [ ] Open Activity page — verify `activity_feed_viewed` fires in PostHog with correct count
- [ ] Type in Activity search — verify `activity_searched` fires ~1s after stopping, not on every keystroke
- [ ] Click "Load more" — verify `activity_load_more` fires with `loaded_so_far`
- [ ] Click an activity row — verify `activity_item_clicked` fires with correct type and actor
- [ ] Open Notifications page, hover a notification, click X — verify `notification_dismissed` fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)