### PR TITLE
fix: replace colons with hyphens in BullMQ queue/worker names

### DIFF
--- a/backend/jobs/digest.job.js
+++ b/backend/jobs/digest.job.js
@@ -176,13 +176,13 @@ async function initDigestJobs() {
     const { Queue, Worker } = require('bullmq');
     const connection = { url: process.env.REDIS_URL };
 
-    const dailyQueue    = new Queue('digest:smart-daily',   { connection });
-    const weeklyQueue   = new Queue('digest:weekly-summary', { connection });
-    const deletionQueue = new Queue('digest:deletion-warn',  { connection });
+    const dailyQueue    = new Queue('digest-smart-daily',   { connection });
+    const weeklyQueue   = new Queue('digest-weekly-summary', { connection });
+    const deletionQueue = new Queue('digest-deletion-warn',  { connection });
 
-    new Worker('digest:smart-daily',   async () => { await runSmartDaily();    }, { connection });
-    new Worker('digest:weekly-summary', async () => { await runWeeklySummary(); }, { connection });
-    new Worker('digest:deletion-warn',  async () => { await runDeletionWarn();  }, { connection });
+    new Worker('digest-smart-daily',   async () => { await runSmartDaily();    }, { connection });
+    new Worker('digest-weekly-summary', async () => { await runWeeklySummary(); }, { connection });
+    new Worker('digest-deletion-warn',  async () => { await runDeletionWarn();  }, { connection });
 
     try {
         await dailyQueue.upsertJobScheduler(

--- a/backend/tests/jest/digest.job.test.js
+++ b/backend/tests/jest/digest.job.test.js
@@ -1,0 +1,68 @@
+/**
+ * digest.job.test.js
+ *
+ * Tests for initDigestJobs — verifies queue and worker names are valid
+ * (no colons, which BullMQ v5 forbids as they clash with Redis key separators).
+ */
+
+jest.mock('bullmq', () => {
+    const QueueMock = jest.fn().mockImplementation((name) => ({
+        name,
+        upsertJobScheduler: jest.fn().mockResolvedValue(undefined),
+    }));
+    const WorkerMock = jest.fn();
+    return { Queue: QueueMock, Worker: WorkerMock };
+});
+
+const { initDigestJobs } = require('../../jobs/digest.job');
+
+describe('initDigestJobs', () => {
+    let savedNodeEnv;
+
+    beforeEach(() => {
+        savedNodeEnv = process.env.NODE_ENV;
+        process.env.NODE_ENV = 'staging';
+        process.env.REDIS_URL = 'redis://localhost:6379';
+        const { Queue, Worker } = require('bullmq');
+        Queue.mockClear();
+        Worker.mockClear();
+    });
+
+    afterEach(() => {
+        process.env.NODE_ENV = savedNodeEnv;
+        delete process.env.REDIS_URL;
+    });
+
+    it('registers 3 queues with no colons in their names', async () => {
+        const { Queue } = require('bullmq');
+        await initDigestJobs();
+        const names = Queue.mock.calls.map(([name]) => name);
+        expect(names).toHaveLength(3);
+        names.forEach(name => expect(name).not.toMatch(/:/));
+    });
+
+    it('registers 3 workers with no colons in their names', async () => {
+        const { Worker } = require('bullmq');
+        await initDigestJobs();
+        const names = Worker.mock.calls.map(([name]) => name);
+        expect(names).toHaveLength(3);
+        names.forEach(name => expect(name).not.toMatch(/:/));
+    });
+
+    it('uses the expected hyphenated queue names', async () => {
+        const { Queue, Worker } = require('bullmq');
+        await initDigestJobs();
+        const queueNames  = Queue.mock.calls.map(([name]) => name).sort();
+        const workerNames = Worker.mock.calls.map(([name]) => name).sort();
+        const expected = ['digest-deletion-warn', 'digest-smart-daily', 'digest-weekly-summary'];
+        expect(queueNames).toEqual(expected);
+        expect(workerNames).toEqual(expected);
+    });
+
+    it('skips queue creation when REDIS_URL is not set', async () => {
+        delete process.env.REDIS_URL;
+        const { Queue } = require('bullmq');
+        await initDigestJobs();
+        expect(Queue).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
## Summary

- BullMQ v5 forbids colons in queue names (they conflict with Redis internal key separators), causing an unhandled rejection that crashed the server on every production startup
- Renamed all three digest queue/worker pairs from `digest:*` to `digest-*` in `backend/jobs/digest.job.js`
- Added `digest.job.test.js` with 4 tests that mock BullMQ and assert no registered queue or worker name contains a colon

## Test plan

- [x] New `digest.job.test.js` — 4 tests pass (validates no colons, correct hyphenated names, Redis URL guard)
- [x] Existing `email.test.js` — 14 tests still pass (no regressions)

Fixes Sentry issue CONTINUUM-BACKEND-4: `Queue name cannot contain :`

🤖 Generated with [Claude Code](https://claude.com/claude-code)