### PR TITLE
fix: mobile footer missing accessibility link + nav CTA

### DIFF
--- a/web/e2e/mobile.spec.ts
+++ b/web/e2e/mobile.spec.ts
@@ -170,6 +170,34 @@ test.describe('Mobile legal pages', () => {
     await page.click('a:has-text("Google Drive Data")');
     await expect(page.locator('#google-drive')).toBeInViewport({ timeout: 2000 });
   });
+
+  test('footer shows accessibility link on mobile gate (/)', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.locator('footer a:has-text("Accessibility")')).toBeVisible();
+  });
+
+  test('footer shows accessibility link on /terms', async ({ page }) => {
+    await page.goto('/terms');
+    await expect(page.locator('footer a:has-text("Accessibility")')).toBeVisible();
+  });
+
+  test('footer shows accessibility link on /privacy', async ({ page }) => {
+    await page.goto('/privacy');
+    await expect(page.locator('footer a:has-text("Accessibility")')).toBeVisible();
+  });
+
+  test('/accessibility nav has "Join the waitlist" not "Get started"', async ({ page }) => {
+    await page.goto('/accessibility');
+    await expect(page.locator('nav a:has-text("Join the waitlist")')).toBeVisible();
+    await expect(page.locator('nav a:has-text("Get started")')).not.toBeVisible();
+  });
+
+  test('"Join the waitlist" on /accessibility navigates to gate and scrolls to form', async ({ page }) => {
+    await page.goto('/accessibility');
+    await page.click('nav a:has-text("Join the waitlist")');
+    await expect(page).toHaveURL('/');
+    await expect(page.locator('#waitlist-form')).toBeInViewport({ timeout: 3000 });
+  });
 });
 
 // ─── Legal pages (desktop UA) ─────────────────────────────────────────────────

--- a/web/src/components/MobileGate.jsx
+++ b/web/src/components/MobileGate.jsx
@@ -395,6 +395,9 @@ export default function MobileGate() {
             <Link to="/terms" style={{ color: '#6B7280', fontSize: '0.75rem', textDecoration: 'underline' }}>
               Terms of Service
             </Link>
+            <Link to="/accessibility" style={{ color: '#6B7280', fontSize: '0.75rem', textDecoration: 'underline' }}>
+              Accessibility
+            </Link>
           </div>
         </div>
       </footer>

--- a/web/src/pages/MobileAccessibilityPage.jsx
+++ b/web/src/pages/MobileAccessibilityPage.jsx
@@ -18,8 +18,8 @@ export default function MobileAccessibilityPage() {
           <Link to="/">
             <img src="/logo-lockup.svg" alt="Continuum" style={{ height: 28 }} />
           </Link>
-          <Link to="/register" style={{ color: '#6B21A8', fontSize: '0.875rem', fontWeight: 600, textDecoration: 'none' }}>
-            Get started
+          <Link to="/" state={{ scrollToForm: true }} style={{ color: '#6B21A8', fontSize: '0.875rem', fontWeight: 600, textDecoration: 'none' }}>
+            Join the waitlist
           </Link>
         </div>
       </nav>

--- a/web/src/pages/MobilePrivacyPage.jsx
+++ b/web/src/pages/MobilePrivacyPage.jsx
@@ -182,6 +182,9 @@ function MobileFooter() {
           <Link to="/terms" style={{ color: '#6B7280', fontSize: '0.75rem', textDecoration: 'underline' }}>
             Terms of Service
           </Link>
+          <Link to="/accessibility" style={{ color: '#6B7280', fontSize: '0.75rem', textDecoration: 'underline' }}>
+            Accessibility
+          </Link>
         </div>
       </div>
     </footer>

--- a/web/src/pages/MobileTermsPage.jsx
+++ b/web/src/pages/MobileTermsPage.jsx
@@ -174,6 +174,9 @@ function MobileFooter() {
           <Link to="/terms" style={{ color: '#6B7280', fontSize: '0.75rem', textDecoration: 'underline' }}>
             Terms of Service
           </Link>
+          <Link to="/accessibility" style={{ color: '#6B7280', fontSize: '0.75rem', textDecoration: 'underline' }}>
+            Accessibility
+          </Link>
         </div>
       </div>
     </footer>


### PR DESCRIPTION
## Summary
- Add missing Accessibility link to the footer on mobile gate (`/`), `/terms`, and `/privacy` pages
- Fix `/accessibility` nav CTA — was showing "Get started" linking to `/register`, now correctly shows "Join the waitlist" linking to `/` with scroll-to-form behavior, matching all other mobile pages
- Add Playwright tests covering all four fixes

## Root Cause
Each mobile legal page defines its own local `MobileFooter` component. The Terms and Privacy footers were only two links (Privacy Policy + Terms of Service), while the Accessibility page's footer happened to have all three. The MobileGate footer had the same omission.

## Tests
5 new tests added to `web/e2e/mobile.spec.ts` under the existing `Mobile legal pages` describe block.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>