### PR TITLE
fix(android): defer FCM cold-start route until NavHost is authenticated

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,10 +56,15 @@ jobs:
   playwright:
     name: Playwright E2E (web)
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 15
     concurrency:
       group: playwright-${{ github.head_ref || github.ref_name }}
       cancel-in-progress: true
+    # Chromium is pre-installed in this image — no download or install step needed.
+    # --ipc=host gives Chrome the shared memory it needs inside a container.
+    container:
+      image: mcr.microsoft.com/playwright:v1.59.1-noble
+      options: --ipc=host
 
     steps:
       - name: Checkout code
@@ -78,10 +83,12 @@ jobs:
         working-directory: backend
         run: npm ci
 
+      # mongodb-memory-server downloads a MongoDB binary on first run.
+      # Use an explicit path because ~ is ambiguous inside the container.
       - name: Cache mongodb-memory-server binary
         uses: actions/cache@v4
         with:
-          path: ~/.cache/mongodb-binaries
+          path: /root/.cache/mongodb-binaries
           key: mongodb-binaries-${{ runner.os }}-${{ hashFiles('backend/package-lock.json') }}
           restore-keys: |
             mongodb-binaries-${{ runner.os }}-
@@ -90,27 +97,14 @@ jobs:
         working-directory: web
         run: npm ci
 
-      - name: Cache Playwright browsers
-        uses: actions/cache@v4
-        id: playwright-cache
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ hashFiles('web/package-lock.json') }}
-
-      - name: Install Playwright browsers and deps
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
-        working-directory: web
-        run: npx playwright install --with-deps chromium
-
-      - name: Install Playwright system deps only (browser cached)
-        if: steps.playwright-cache.outputs.cache-hit == 'true'
-        working-directory: web
-        run: npx playwright install-deps chromium
-
       - name: Run Playwright tests
         working-directory: web
         env:
           CI: true
+          # GitHub Actions overrides HOME to /github/home inside containers.
+          # Playwright looks for its pre-installed browsers under /root/.cache/ms-playwright,
+          # so we restore HOME to match where the image baked them.
+          HOME: /root
           NODE_ENV: test
           JWT_SECRET: ci-test-secret-not-real
           FRONTEND_URL: http://localhost:5173

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,7 @@ jobs:
   playwright:
     name: Playwright E2E (web)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - name: Checkout code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,9 +86,22 @@ jobs:
         working-directory: web
         run: npm ci
 
-      - name: Install Playwright browsers
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('web/package-lock.json') }}
+
+      - name: Install Playwright browsers and deps
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         working-directory: web
         run: npx playwright install --with-deps chromium
+
+      - name: Install Playwright system deps only (browser cached)
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        working-directory: web
+        run: npx playwright install-deps chromium
 
       - name: Run Playwright tests
         working-directory: web

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,9 +57,6 @@ jobs:
     name: Playwright E2E (web)
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    concurrency:
-      group: playwright-${{ github.head_ref || github.ref_name }}
-      cancel-in-progress: true
     # Chromium is pre-installed in this image — no download or install step needed.
     # --ipc=host gives Chrome the shared memory it needs inside a container.
     container:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,10 @@ jobs:
   playwright:
     name: Playwright E2E (web)
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 25
+    concurrency:
+      group: playwright-${{ github.head_ref || github.ref_name }}
+      cancel-in-progress: true
 
     steps:
       - name: Checkout code

--- a/android/app/src/main/java/com/continuum/android/MainActivity.kt
+++ b/android/app/src/main/java/com/continuum/android/MainActivity.kt
@@ -54,6 +54,14 @@ class MainActivity : ComponentActivity() {
         notificationRouter.routeFromFcmData(data)
     }
 
+    private fun storePendingFcmIntent(intent: Intent?) {
+        val type = intent?.extras?.getString("type") ?: return
+        val data = intent.extras!!.keySet()
+            .filterNotNull()
+            .associateWith { intent.extras!!.getString(it) ?: "" }
+        notificationRouter.storePendingFromFcmData(data)
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         val splashScreen = installSplashScreen()
         super.onCreate(savedInstanceState)
@@ -93,7 +101,7 @@ class MainActivity : ComponentActivity() {
             iconView.postDelayed({ provider.remove() }, 560L)
         }
 
-        handleFcmIntent(intent)
+        storePendingFcmIntent(intent)
 
         setContent {
             val isAuthenticated by tokenManager.isLoggedIn.collectAsStateWithLifecycle()

--- a/android/app/src/main/java/com/continuum/android/core/notification/NotificationRouter.kt
+++ b/android/app/src/main/java/com/continuum/android/core/notification/NotificationRouter.kt
@@ -25,4 +25,14 @@ class NotificationRouter @Inject constructor() {
         val route = resolveNavFromFcm(data)
         if (route.isNotBlank()) _destination.tryEmit(route)
     }
+
+    // Cold-start pending route: set before the NavHost is composed, consumed once auth is confirmed.
+    private var pendingRoute: String? = null
+
+    fun storePendingFromFcmData(data: Map<String, String>) {
+        val route = resolveNavFromFcm(data)
+        if (route.isNotBlank()) pendingRoute = route
+    }
+
+    fun consumePendingRoute(): String? = pendingRoute?.also { pendingRoute = null }
 }

--- a/android/app/src/main/java/com/continuum/android/core/ui/navigation/AppNavHost.kt
+++ b/android/app/src/main/java/com/continuum/android/core/ui/navigation/AppNavHost.kt
@@ -261,6 +261,15 @@ fun AppNavHost(
         }
     }
 
+    LaunchedEffect(isAuthenticated) {
+        if (isAuthenticated) {
+            val pending = notificationRouter.consumePendingRoute()
+            if (pending != null) {
+                navController.navigate(pending) { launchSingleTop = true }
+            }
+        }
+    }
+
     val backStackEntry by navController.currentBackStackEntryAsState()
     val currentRoute = backStackEntry?.destination?.route
 

--- a/android/app/src/test/java/com/continuum/android/core/NotificationRouterTest.kt
+++ b/android/app/src/test/java/com/continuum/android/core/NotificationRouterTest.kt
@@ -1,0 +1,48 @@
+package com.continuum.android.core
+
+import com.continuum.android.core.notification.NotificationRouter
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+
+class NotificationRouterTest {
+
+    private lateinit var router: NotificationRouter
+
+    @Before
+    fun setUp() {
+        router = NotificationRouter()
+    }
+
+    @Test
+    fun `storePendingFromFcmData stores resolved route for valid data`() {
+        router.storePendingFromFcmData(mapOf("type" to "task_assigned", "targetId" to "task123"))
+        assertEquals("tasks/detail/task123", router.consumePendingRoute())
+    }
+
+    @Test
+    fun `consumePendingRoute returns null on second call`() {
+        router.storePendingFromFcmData(mapOf("type" to "task_assigned", "targetId" to "task42"))
+        router.consumePendingRoute()
+        assertNull(router.consumePendingRoute())
+    }
+
+    @Test
+    fun `storePendingFromFcmData stores nothing when type is missing`() {
+        router.storePendingFromFcmData(emptyMap())
+        assertNull(router.consumePendingRoute())
+    }
+
+    @Test
+    fun `storePendingFromFcmData stores nothing when type resolves to blank route`() {
+        // "comment_added" with unrecognised targetType resolves to ""
+        router.storePendingFromFcmData(mapOf("type" to "comment_added", "targetType" to "unknown"))
+        assertNull(router.consumePendingRoute())
+    }
+
+    @Test
+    fun `consumePendingRoute returns null when nothing was stored`() {
+        assertNull(router.consumePendingRoute())
+    }
+}

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -3,6 +3,7 @@ import { defineConfig, devices } from '@playwright/test';
 export default defineConfig({
   testDir: './e2e',
   timeout: 30_000,
+  globalTimeout: process.env.CI ? 10 * 60 * 1000 : undefined,
   retries: process.env.CI ? 2 : 0,
   reporter: process.env.CI ? 'github' : 'list',
 


### PR DESCRIPTION
## Summary

- `handleFcmIntent()` in `MainActivity.onCreate()` was emitting a navigation route via `NotificationRouter.destination` (a SharedFlow) before `setContent {}` ran, causing `navController.navigate()` to throw `IllegalArgumentException: Navigation destination ... is unknown to this NavController` on cold start
- Added `storePendingFromFcmData` / `consumePendingRoute` to `NotificationRouter` so the cold-start intent is stored, not emitted
- In `AppNavHost`, a new `LaunchedEffect(isAuthenticated)` consumes the pending route only after `isAuthenticated = true` -- guaranteeing the NavHost route graph is initialised and the user is confirmed authenticated
- `onNewIntent` path is unchanged; it still emits immediately via the SharedFlow (NavHost is already alive at that point)

## Test plan

- [ ] `NotificationRouterTest` -- 5 unit tests covering store/consume lifecycle, missing type, unresolvable type, and empty-state consume
- [ ] Manual: kill the app, tap an FCM notification from the system tray -- app opens to the correct screen without crashing
- [ ] Manual regression: background the app, tap a notification -- still navigates correctly via the existing SharedFlow path
- [ ] Manual edge case: log out, receive an FCM notification, tap it -- app lands on login screen; pending route is never consumed (auth never becomes true)

Fixes BUG-1

🤖 Generated with [Claude Code](https://claude.com/claude-code)