### PR TITLE
fix: attach error handlers to socket.io Redis pub/sub clients

### DIFF
--- a/backend/lib/socket.js
+++ b/backend/lib/socket.js
@@ -26,6 +26,8 @@ async function initSocket(httpServer) {
     try {
       const pubClient = createClient({ url: process.env.REDIS_URL });
       const subClient = pubClient.duplicate();
+      pubClient.on('error', (err) => logger.warn({ err }, 'Redis pub client error'));
+      subClient.on('error', (err) => logger.warn({ err }, 'Redis sub client error'));
       await Promise.all([pubClient.connect(), subClient.connect()]);
       io.adapter(createAdapter(pubClient, subClient));
     } catch (err) {


### PR DESCRIPTION
## Summary
- `pubClient`/`subClient` for the Socket.IO Redis adapter in `backend/lib/socket.js` were connected without an `.on('error', ...)` listener, unlike `lib/cache.js`.
- Render logs showed a recurring `missing 'error' handler on this Redis client` warning every ~6 hours since 2026-06-19, consistent with Upstash dropping idle connections periodically.
- Adds error listeners that log via the existing logger, matching the established pattern in `lib/cache.js`.

## Test plan
- [x] `node --check backend/lib/socket.js` passes
- [x] Deploy and confirm the recurring warning stops appearing in Render logs